### PR TITLE
Stop calling LatLong stuff GeoCoordinate

### DIFF
--- a/Aliases.php
+++ b/Aliases.php
@@ -21,3 +21,23 @@ namespace DataValues {
 	class GlobeCoordinateValue extends \DataValues\Geo\Values\GlobeCoordinateValue {}
 
 }
+
+namespace DataValues\Geo\Formatters {
+
+	/**
+	 * @since 1.0
+	 * @deprecated since 2.0, use the base class instead.
+	 */
+	class GeoCoordinateFormatter extends \DataValues\Geo\Formatters\LatLongFormatter {}
+
+}
+
+namespace DataValues\Geo\Parsers {
+
+	/**
+	 * @since 1.0
+	 * @deprecated since 2.0, use the base class instead.
+	 */
+	class GeoCoordinateParser extends \DataValues\Geo\Parsers\LatLongParser {}
+
+}

--- a/Geo.php
+++ b/Geo.php
@@ -35,3 +35,7 @@ if ( defined( 'MEDIAWIKI' ) ) {
 // Aliases introduced in 1.0
 class_alias( 'DataValues\Geo\Values\LatLongValue', 'DataValues\LatLongValue' );
 class_alias( 'DataValues\Geo\Values\GlobeCoordinateValue', 'DataValues\GlobeCoordinateValue' );
+
+// Aliases introduced in 2.0
+class_alias( 'DataValues\Geo\Formatters\LatLongFormatter', 'DataValues\Geo\Formatters\GeoCoordinateFormatter' );
+class_alias( 'DataValues\Geo\Parsers\LatLongParser', 'DataValues\Geo\Parsers\GeoCoordinateParser' );

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ These are simple value objects. They all implement the <code>DataValues\DataValu
 These turn value objects into string representations.
 They all implement the <code>ValueFormatters\ValueFormatter</code> interface.
 
-* <code>GeoCoordinateFormatter</code> - Formats a LatLongValue into float, decimal minute,
+* <code>LatLongFormatter</code> - Formats a LatLongValue into float, decimal minute,
 decimal degree or degree minute second notation. Both directional and non-directional notation
 are supported. Directional labels, latitude-longitude separator and precision can be specified.
 * <code>GlobeCoordinateFormatter</code> - Formats a GlobeCoordinateValue.
@@ -70,7 +70,7 @@ Simple parsers:
 
 Composite parsers:
 
-* <code>GeoCoordinateParser</code> - Facade for DdCoordinateParser, DmCoordinateParser, DmsCoordinateParser
+* <code>LatLongParser</code> - Facade for DdCoordinateParser, DmCoordinateParser, DmsCoordinateParser
 and FloatCoordinateParser. Parses a coordinate in any of the notations supported by these parsers
 into a LatLongValue object. Both directional and non-directional notation are supported. Directional
 labels and the latitude-longitude separator can be specified.
@@ -92,6 +92,12 @@ It is based upon and contains a lot of code written by [Jeroen De Dauw]
 [Semantic MediaWiki](https://semantic-mediawiki.org/) projects.
 
 ## Release notes
+
+### 2.0.0 (dev)
+
+* Renamed `GeoCoordinateFormatter` to `LatLongFormatter`, leaving a deprecated alias.
+* Renamed `GeoCoordinateParser` to `LatLongParser`, leaving a deprecated alias.
+* Renamed `GeoCoordinateParserBase` to `LatLongParserBase`.
 
 ### 1.2.2 (2017-03-14)
 

--- a/src/Formatters/GlobeCoordinateFormatter.php
+++ b/src/Formatters/GlobeCoordinateFormatter.php
@@ -10,9 +10,9 @@ use ValueFormatters\ValueFormatterBase;
  * Geographical coordinates formatter.
  * Formats GlobeCoordinateValue objects.
  *
- * Formatting of latitude and longitude is done via GeoCoordinateFormatter.
+ * Formatting of latitude and longitude is done via LatLongFormatter.
  *
- * For now this is a trivial implementation that only forwards to GeoCoordinateFormatter.
+ * For now this is a trivial implementation that only forwards to LatLongFormatter.
  * TODO: add formatting of globe and precision
  *
  * @since 0.1
@@ -35,7 +35,7 @@ class GlobeCoordinateFormatter extends ValueFormatterBase {
 			throw new InvalidArgumentException( 'Data value type mismatch. Expected a GlobeCoordinateValue.' );
 		}
 
-		$formatter = new GeoCoordinateFormatter( $this->options );
+		$formatter = new LatLongFormatter( $this->options );
 
 		return $formatter->formatLatLongValue( $value->getLatLong(), $value->getPrecision() );
 	}

--- a/src/Formatters/LatLongFormatter.php
+++ b/src/Formatters/LatLongFormatter.php
@@ -27,7 +27,7 @@ use ValueFormatters\ValueFormatterBase;
  * @author Addshore
  * @author Thiemo Mättig
  */
-class GeoCoordinateFormatter extends ValueFormatterBase {
+class LatLongFormatter extends ValueFormatterBase {
 
 	/**
 	 * Output formats for use with the self::OPT_FORMAT option.

--- a/src/Parsers/DdCoordinateParser.php
+++ b/src/Parsers/DdCoordinateParser.php
@@ -14,7 +14,7 @@ use ValueParsers\ParserOptions;
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author H. Snater < mediawiki@snater.com >
  */
-class DdCoordinateParser extends GeoCoordinateParserBase {
+class DdCoordinateParser extends LatLongParserBase {
 
 	/**
 	 * The symbol representing degrees.
@@ -34,7 +34,7 @@ class DdCoordinateParser extends GeoCoordinateParserBase {
 	}
 
 	/**
-	 * @see GeoCoordinateParserBase::getParsedCoordinate
+	 * @see LatLongParserBase::getParsedCoordinate
 	 *
 	 * @param string $coordinateSegment
 	 *
@@ -46,7 +46,7 @@ class DdCoordinateParser extends GeoCoordinateParserBase {
 	}
 
 	/**
-	 * @see GeoCoordinateParserBase::areValidCoordinates
+	 * @see LatLongParserBase::areValidCoordinates
 	 *
 	 * @param string[] $normalizedCoordinateSegments
 	 *
@@ -101,7 +101,7 @@ class DdCoordinateParser extends GeoCoordinateParserBase {
 	}
 
 	/**
-	 * @see GeoCoordinateParserBase::stringParse
+	 * @see LatLongParserBase::stringParse
 	 *
 	 * @param string $value
 	 *
@@ -133,7 +133,7 @@ class DdCoordinateParser extends GeoCoordinateParserBase {
 	 * Returns a string with whitespace, control characters and characters with ASCII values above
 	 * 126 removed.
 	 *
-	 * @see GeoCoordinateParserBase::removeInvalidChars
+	 * @see LatLongParserBase::removeInvalidChars
 	 *
 	 * @param string $string
 	 *
@@ -159,7 +159,7 @@ class DdCoordinateParser extends GeoCoordinateParserBase {
 	}
 
 	/**
-	 * @see GeoCoordinateParserBase::splitString
+	 * @see LatLongParserBase::splitString
 	 *
 	 * @param string $normalizedCoordinateString
 	 *

--- a/src/Parsers/DmCoordinateParser.php
+++ b/src/Parsers/DmCoordinateParser.php
@@ -36,7 +36,7 @@ class DmCoordinateParser extends DdCoordinateParser {
 	}
 
 	/**
-	 * @see GeoCoordinateParserBase::areValidCoordinates
+	 * @see LatLongParserBase::areValidCoordinates
 	 *
 	 * @param string[] $normalizedCoordinateSegments
 	 *

--- a/src/Parsers/DmsCoordinateParser.php
+++ b/src/Parsers/DmsCoordinateParser.php
@@ -36,7 +36,7 @@ class DmsCoordinateParser extends DmCoordinateParser {
 	}
 
 	/**
-	 * @see GeoCoordinateParserBase::areValidCoordinates
+	 * @see LatLongParserBase::areValidCoordinates
 	 *
 	 * @param string[] $normalizedCoordinateSegments
 	 *

--- a/src/Parsers/FloatCoordinateParser.php
+++ b/src/Parsers/FloatCoordinateParser.php
@@ -11,12 +11,12 @@ use ValueParsers\ParseException;
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author H. Snater < mediawiki@snater.com >
  */
-class FloatCoordinateParser extends GeoCoordinateParserBase {
+class FloatCoordinateParser extends LatLongParserBase {
 
 	const FORMAT_NAME = 'float-coordinate';
 
 	/**
-	 * @see GeoCoordinateParserBase::getParsedCoordinate
+	 * @see LatLongParserBase::getParsedCoordinate
 	 *
 	 * @param string $coordinateSegment
 	 *
@@ -27,7 +27,7 @@ class FloatCoordinateParser extends GeoCoordinateParserBase {
 	}
 
 	/**
-	 * @see GeoCoordinateParserBase::areValidCoordinates
+	 * @see LatLongParserBase::areValidCoordinates
 	 *
 	 * @param string[] $normalizedCoordinateSegments
 	 *
@@ -80,7 +80,7 @@ class FloatCoordinateParser extends GeoCoordinateParserBase {
 	}
 
 	/**
-	 * @see GeoCoordinateParserBase::splitString
+	 * @see LatLongParserBase::splitString
 	 *
 	 * @param string $normalizedCoordinateString
 	 *

--- a/src/Parsers/GlobeCoordinateParser.php
+++ b/src/Parsers/GlobeCoordinateParser.php
@@ -9,7 +9,7 @@ use ValueParsers\ParserOptions;
 use ValueParsers\StringValueParser;
 
 /**
- * Extends the GeoCoordinateParser by adding precision detection support.
+ * Extends the LatLongParser by adding precision detection support.
  *
  * The object that gets constructed is a GlobeCoordinateValue rather then a LatLongValue.
  *

--- a/src/Parsers/LatLongParser.php
+++ b/src/Parsers/LatLongParser.php
@@ -31,7 +31,7 @@ use ValueParsers\StringValueParser;
  * @license GPL-2.0+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-class GeoCoordinateParser extends StringValueParser {
+class LatLongParser extends StringValueParser {
 
 	const TYPE_FLOAT = 'float';
 	const TYPE_DMS = 'dms';

--- a/src/Parsers/LatLongParserBase.php
+++ b/src/Parsers/LatLongParserBase.php
@@ -14,7 +14,7 @@ use ValueParsers\StringValueParser;
  * @author H. Snater < mediawiki@snater.com >
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-abstract class GeoCoordinateParserBase extends StringValueParser {
+abstract class LatLongParserBase extends StringValueParser {
 
 	const FORMAT_NAME = 'geo-coordinate';
 

--- a/tests/unit/Formatters/GlobeCoordinateFormatterTest.php
+++ b/tests/unit/Formatters/GlobeCoordinateFormatterTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\DataValues\Geo\Formatters;
 
-use DataValues\Geo\Formatters\GeoCoordinateFormatter;
+use DataValues\Geo\Formatters\LatLongFormatter;
 use DataValues\Geo\Formatters\GlobeCoordinateFormatter;
 use DataValues\Geo\Parsers\GlobeCoordinateParser;
 use DataValues\Geo\Values\GlobeCoordinateValue;
@@ -85,17 +85,17 @@ class GlobeCoordinateFormatterTest extends ValueFormatterTestBase {
 		$argLists = array();
 
 		$tests = array(
-			GeoCoordinateFormatter::TYPE_FLOAT => $floats,
-			GeoCoordinateFormatter::TYPE_DD => $decimalDegrees,
-			GeoCoordinateFormatter::TYPE_DMS => $dmsCoordinates,
-			GeoCoordinateFormatter::TYPE_DM => $dmCoordinates,
+			LatLongFormatter::TYPE_FLOAT => $floats,
+			LatLongFormatter::TYPE_DD => $decimalDegrees,
+			LatLongFormatter::TYPE_DMS => $dmsCoordinates,
+			LatLongFormatter::TYPE_DM => $dmCoordinates,
 		);
 
 		$i = 0;
 		foreach ( $tests as $format => $coords ) {
 			foreach ( $coords as $expectedOutput => $arguments ) {
 				$options = new FormatterOptions();
-				$options->setOption( GeoCoordinateFormatter::OPT_FORMAT, $format );
+				$options->setOption( LatLongFormatter::OPT_FORMAT, $format );
 
 				$input = new GlobeCoordinateValue(
 					new LatLongValue( $arguments[0], $arguments[1] ),
@@ -114,7 +114,7 @@ class GlobeCoordinateFormatterTest extends ValueFormatterTestBase {
 
 	public function testFormatWithInvalidPrecision_fallsBackToDefaultPrecision() {
 		$options = new FormatterOptions();
-		$options->setOption( GeoCoordinateFormatter::OPT_PRECISION, 0 );
+		$options->setOption( LatLongFormatter::OPT_PRECISION, 0 );
 		$formatter = new GlobeCoordinateFormatter( $options );
 
 		$formatted = $formatter->format( new GlobeCoordinateValue( new LatLongValue( 1.2, 3.4 ), null ) );

--- a/tests/unit/Formatters/LatLongFormatterTest.php
+++ b/tests/unit/Formatters/LatLongFormatterTest.php
@@ -2,14 +2,14 @@
 
 namespace Tests\DataValues\Geo\Formatters;
 
-use DataValues\Geo\Formatters\GeoCoordinateFormatter;
-use DataValues\Geo\Parsers\GeoCoordinateParser;
+use DataValues\Geo\Formatters\LatLongFormatter;
+use DataValues\Geo\Parsers\LatLongParser;
 use DataValues\Geo\Values\LatLongValue;
 use DataValues\StringValue;
 use ValueFormatters\FormatterOptions;
 
 /**
- * @covers DataValues\Geo\Formatters\GeoCoordinateFormatter
+ * @covers DataValues\Geo\Formatters\LatLongFormatter
  *
  * @group ValueFormatters
  * @group DataValueExtensions
@@ -19,7 +19,7 @@ use ValueFormatters\FormatterOptions;
  * @author Addshore
  * @author Daniel Kinzler
  */
-class GeoCoordinateFormatterTest extends \PHPUnit_Framework_TestCase {
+class LatLongFormatterTest extends \PHPUnit_Framework_TestCase {
 
 	public function floatNotationProvider() {
 		return array(
@@ -87,16 +87,16 @@ class GeoCoordinateFormatterTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @param string $format One of the GeoCoordinateFormatter::TYPE_… constants
+	 * @param string $format One of the LatLongFormatter::TYPE_… constants
 	 * @param float|int $precision
 	 *
 	 * @return FormatterOptions
 	 */
 	private function makeOptions( $format, $precision ) {
 		$options = new FormatterOptions();
-		$options->setOption( GeoCoordinateFormatter::OPT_FORMAT, $format );
-		$options->setOption( GeoCoordinateFormatter::OPT_DIRECTIONAL, false );
-		$options->setOption( GeoCoordinateFormatter::OPT_PRECISION, $precision );
+		$options->setOption( LatLongFormatter::OPT_FORMAT, $format );
+		$options->setOption( LatLongFormatter::OPT_DIRECTIONAL, false );
+		$options->setOption( LatLongFormatter::OPT_PRECISION, $precision );
 
 		return $options;
 	}
@@ -105,7 +105,7 @@ class GeoCoordinateFormatterTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider floatNotationProvider
 	 */
 	public function testFloatNotationFormatting( LatLongValue $latLong, $precision, $expected ) {
-		$options = $this->makeOptions( GeoCoordinateFormatter::TYPE_FLOAT, $precision );
+		$options = $this->makeOptions( LatLongFormatter::TYPE_FLOAT, $precision );
 		$this->assertFormatsCorrectly( $latLong, $options, $expected );
 	}
 
@@ -113,7 +113,7 @@ class GeoCoordinateFormatterTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider floatNotationProvider
 	 */
 	public function testFloatNotationRoundTrip( LatLongValue $value, $precision, $expected ) {
-		$options = $this->makeOptions( GeoCoordinateFormatter::TYPE_FLOAT, $precision );
+		$options = $this->makeOptions( LatLongFormatter::TYPE_FLOAT, $precision );
 		$this->assertRoundTrip( $value, $options );
 	}
 
@@ -186,7 +186,7 @@ class GeoCoordinateFormatterTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider decimalDegreeNotationProvider
 	 */
 	public function testDecimalDegreeNotationFormatting( LatLongValue $latLong, $precision, $expected ) {
-		$options = $this->makeOptions( GeoCoordinateFormatter::TYPE_DD, $precision );
+		$options = $this->makeOptions( LatLongFormatter::TYPE_DD, $precision );
 		$this->assertFormatsCorrectly( $latLong, $options, $expected );
 	}
 
@@ -194,7 +194,7 @@ class GeoCoordinateFormatterTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider decimalDegreeNotationProvider
 	 */
 	public function testDecimalDegreeNotationRoundTrip( LatLongValue $latLong, $precision, $expected ) {
-		$options = $this->makeOptions( GeoCoordinateFormatter::TYPE_DD, $precision );
+		$options = $this->makeOptions( LatLongFormatter::TYPE_DD, $precision );
 		$this->assertRoundTrip( $latLong, $options );
 	}
 
@@ -297,7 +297,7 @@ class GeoCoordinateFormatterTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider decimalMinuteNotationProvider
 	 */
 	public function testDecimalMinuteNotationFormatting( LatLongValue $latLong, $precision, $expected ) {
-		$options = $this->makeOptions( GeoCoordinateFormatter::TYPE_DM, $precision );
+		$options = $this->makeOptions( LatLongFormatter::TYPE_DM, $precision );
 		$this->assertFormatsCorrectly( $latLong, $options, $expected );
 	}
 
@@ -305,7 +305,7 @@ class GeoCoordinateFormatterTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider decimalMinuteNotationProvider
 	 */
 	public function testDecimalMinuteNotationRoundTrip( LatLongValue $latLong, $precision, $expected ) {
-		$options = $this->makeOptions( GeoCoordinateFormatter::TYPE_DM, $precision );
+		$options = $this->makeOptions( LatLongFormatter::TYPE_DM, $precision );
 		$this->assertRoundTrip( $latLong, $options );
 	}
 
@@ -458,7 +458,7 @@ class GeoCoordinateFormatterTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider decimalMinuteSecondNotationProvider
 	 */
 	public function testDecimalMinuteSecondNotationFormatting( LatLongValue $latLong, $precision, $expected ) {
-		$options = $this->makeOptions( GeoCoordinateFormatter::TYPE_DMS, $precision );
+		$options = $this->makeOptions( LatLongFormatter::TYPE_DMS, $precision );
 		$this->assertFormatsCorrectly( $latLong, $options, $expected );
 	}
 
@@ -466,7 +466,7 @@ class GeoCoordinateFormatterTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider decimalMinuteSecondNotationProvider
 	 */
 	public function testDecimalMinuteSecondNotationRoundTrip( LatLongValue $latLong, $precision, $expected ) {
-		$options = $this->makeOptions( GeoCoordinateFormatter::TYPE_DMS, $precision );
+		$options = $this->makeOptions( LatLongFormatter::TYPE_DMS, $precision );
 		$this->assertRoundTrip( $latLong, $options );
 	}
 
@@ -476,7 +476,7 @@ class GeoCoordinateFormatterTest extends \PHPUnit_Framework_TestCase {
 	 * @param string $expected
 	 */
 	private function assertFormatsCorrectly( LatLongValue $latLong, FormatterOptions $options, $expected ) {
-		$formatter = new GeoCoordinateFormatter( $options );
+		$formatter = new LatLongFormatter( $options );
 
 		$this->assertSame(
 			$expected,
@@ -484,7 +484,7 @@ class GeoCoordinateFormatterTest extends \PHPUnit_Framework_TestCase {
 			'format()'
 		);
 
-		$precision = $options->getOption( GeoCoordinateFormatter::OPT_PRECISION );
+		$precision = $options->getOption( LatLongFormatter::OPT_PRECISION );
 		$this->assertSame(
 			$expected,
 			$formatter->formatLatLongValue( $latLong, $precision ),
@@ -493,8 +493,8 @@ class GeoCoordinateFormatterTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	private function assertRoundTrip( LatLongValue $value, FormatterOptions $options ) {
-		$formatter = new GeoCoordinateFormatter( $options );
-		$parser = new GeoCoordinateParser();
+		$formatter = new LatLongFormatter( $options );
+		$parser = new LatLongParser();
 
 		$formatted = $formatter->format( $value );
 		$parsed = $parser->parse( $formatted );
@@ -514,19 +514,19 @@ class GeoCoordinateFormatterTest extends \PHPUnit_Framework_TestCase {
 			'0° 0\' N, 0° 0\' E' => array( 0, 0 ),
 		);
 
-		$this->assertIsDirectionalFormatMap( $coordinates, GeoCoordinateFormatter::TYPE_DM );
+		$this->assertIsDirectionalFormatMap( $coordinates, LatLongFormatter::TYPE_DM );
 	}
 
 	/**
 	 * @param array[] $coordinates
-	 * @param string $format One of the GeoCoordinateFormatter::TYPE_… constants
+	 * @param string $format One of the LatLongFormatter::TYPE_… constants
 	 */
 	private function assertIsDirectionalFormatMap( array $coordinates, $format ) {
 		foreach ( $coordinates as $expected => $arguments ) {
 			$options = new FormatterOptions();
-			$options->setOption( GeoCoordinateFormatter::OPT_FORMAT, $format );
-			$options->setOption( GeoCoordinateFormatter::OPT_DIRECTIONAL, true );
-			$options->setOption( GeoCoordinateFormatter::OPT_PRECISION, 1 / 60 );
+			$options->setOption( LatLongFormatter::OPT_FORMAT, $format );
+			$options->setOption( LatLongFormatter::OPT_DIRECTIONAL, true );
+			$options->setOption( LatLongFormatter::OPT_PRECISION, 1 / 60 );
 
 			$this->assertFormatsCorrectly(
 				new LatLongValue( $arguments[0], $arguments[1] ),
@@ -545,23 +545,23 @@ class GeoCoordinateFormatterTest extends \PHPUnit_Framework_TestCase {
 			'0 N, 0 E' => array( 0, 0 ),
 		);
 
-		$this->assertIsDirectionalFormatMap( $coordinates, GeoCoordinateFormatter::TYPE_FLOAT );
+		$this->assertIsDirectionalFormatMap( $coordinates, LatLongFormatter::TYPE_FLOAT );
 	}
 
 	private function provideSpacingLevelOptions() {
 		return array(
 			'none' => array(),
-			'latlong' => array( GeoCoordinateFormatter::OPT_SPACE_LATLONG ),
-			'direction' => array( GeoCoordinateFormatter::OPT_SPACE_DIRECTION ),
-			'coordparts' => array( GeoCoordinateFormatter::OPT_SPACE_COORDPARTS ),
+			'latlong' => array( LatLongFormatter::OPT_SPACE_LATLONG ),
+			'direction' => array( LatLongFormatter::OPT_SPACE_DIRECTION ),
+			'coordparts' => array( LatLongFormatter::OPT_SPACE_COORDPARTS ),
 			'latlong_direction' => array(
-				GeoCoordinateFormatter::OPT_SPACE_LATLONG,
-				GeoCoordinateFormatter::OPT_SPACE_DIRECTION
+				LatLongFormatter::OPT_SPACE_LATLONG,
+				LatLongFormatter::OPT_SPACE_DIRECTION
 			),
 			'all' => array(
-				GeoCoordinateFormatter::OPT_SPACE_LATLONG,
-				GeoCoordinateFormatter::OPT_SPACE_DIRECTION,
-				GeoCoordinateFormatter::OPT_SPACE_COORDPARTS,
+				LatLongFormatter::OPT_SPACE_LATLONG,
+				LatLongFormatter::OPT_SPACE_DIRECTION,
+				LatLongFormatter::OPT_SPACE_COORDPARTS,
 			),
 		);
 	}
@@ -595,22 +595,22 @@ class GeoCoordinateFormatterTest extends \PHPUnit_Framework_TestCase {
 			),
 		);
 
-		$this->assertSpacingCorrect( $coordinates, GeoCoordinateFormatter::TYPE_DM );
+		$this->assertSpacingCorrect( $coordinates, LatLongFormatter::TYPE_DM );
 	}
 
 	/**
 	 * @param array[] $coordSets
-	 * @param string $format One of the GeoCoordinateFormatter::TYPE_… constants
+	 * @param string $format One of the LatLongFormatter::TYPE_… constants
 	 */
 	private function assertSpacingCorrect( array $coordSets, $format ) {
 		$spacingLevelOptions = $this->provideSpacingLevelOptions();
 		foreach ( $coordSets as $spacingKey => $coordinates ) {
 			foreach ( $coordinates as $expected => $arguments ) {
 				$options = new FormatterOptions();
-				$options->setOption( GeoCoordinateFormatter::OPT_FORMAT, $format );
-				$options->setOption( GeoCoordinateFormatter::OPT_DIRECTIONAL, true );
-				$options->setOption( GeoCoordinateFormatter::OPT_PRECISION, 1 / 60 );
-				$options->setOption( GeoCoordinateFormatter::OPT_SPACING_LEVEL, $spacingLevelOptions[$spacingKey] );
+				$options->setOption( LatLongFormatter::OPT_FORMAT, $format );
+				$options->setOption( LatLongFormatter::OPT_DIRECTIONAL, true );
+				$options->setOption( LatLongFormatter::OPT_PRECISION, 1 / 60 );
+				$options->setOption( LatLongFormatter::OPT_SPACING_LEVEL, $spacingLevelOptions[$spacingKey] );
 
 				$this->assertFormatsCorrectly(
 					new LatLongValue( $arguments[0], $arguments[1] ),
@@ -649,21 +649,21 @@ class GeoCoordinateFormatterTest extends \PHPUnit_Framework_TestCase {
 			),
 		);
 
-		$this->assertSpacingCorrect( $coordinates, GeoCoordinateFormatter::TYPE_FLOAT );
+		$this->assertSpacingCorrect( $coordinates, LatLongFormatter::TYPE_FLOAT );
 	}
 
 	public function testWrongType() {
 		$this->setExpectedException( 'InvalidArgumentException' );
 
-		$formatter = new GeoCoordinateFormatter( new FormatterOptions() );
+		$formatter = new LatLongFormatter( new FormatterOptions() );
 
 		$formatter->format( new StringValue( 'Evil' ) );
 	}
 
 	public function testGivenInvalidFormattingOption_formatThrowsException() {
 		$options = new FormatterOptions();
-		$options->setOption( GeoCoordinateFormatter::OPT_FORMAT, 'not a format' );
-		$formatter = new GeoCoordinateFormatter( $options );
+		$options->setOption( LatLongFormatter::OPT_FORMAT, 'not a format' );
+		$formatter = new LatLongFormatter( $options );
 
 		$this->setExpectedException( 'InvalidArgumentException' );
 		$formatter->format( new LatLongValue( 0, 0 ) );
@@ -674,8 +674,8 @@ class GeoCoordinateFormatterTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testFormatWithInvalidPrecision_fallsBackToDefaultPrecision( $precision ) {
 		$options = new FormatterOptions();
-		$options->setOption( GeoCoordinateFormatter::OPT_PRECISION, $precision );
-		$formatter = new GeoCoordinateFormatter( $options );
+		$options->setOption( LatLongFormatter::OPT_PRECISION, $precision );
+		$formatter = new LatLongFormatter( $options );
 
 		$formatted = $formatter->format( new LatLongValue( 1.2, 3.4 ) );
 		$this->assertSame( '1.2, 3.4', $formatted );
@@ -685,7 +685,7 @@ class GeoCoordinateFormatterTest extends \PHPUnit_Framework_TestCase {
 	 * @dataProvider invalidPrecisionProvider
 	 */
 	public function testFormatLatLongValueWithInvalidPrecision_fallsBackToDefaultPrecision( $precision ) {
-		$formatter = new GeoCoordinateFormatter( new FormatterOptions() );
+		$formatter = new LatLongFormatter( new FormatterOptions() );
 
 		$formatted = $formatter->formatLatLongValue( new LatLongValue( 1.2, 3.4 ), $precision );
 		$this->assertSame( '1.2, 3.4', $formatted );

--- a/tests/unit/Parsers/LatLongParserTest.php
+++ b/tests/unit/Parsers/LatLongParserTest.php
@@ -2,12 +2,12 @@
 
 namespace Tests\DataValues\Geo\Parsers;
 
-use DataValues\Geo\Parsers\GeoCoordinateParser;
+use DataValues\Geo\Parsers\LatLongParser;
 use DataValues\Geo\Values\LatLongValue;
 use ValueParsers\Test\StringValueParserTest;
 
 /**
- * @covers DataValues\Geo\Parsers\GeoCoordinateParser
+ * @covers DataValues\Geo\Parsers\LatLongParser
  *
  * @group ValueParsers
  * @group DataValueExtensions
@@ -15,7 +15,7 @@ use ValueParsers\Test\StringValueParserTest;
  * @license GPL-2.0+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-class GeoCoordinateParserTest extends StringValueParserTest {
+class LatLongParserTest extends StringValueParserTest {
 
 	/**
 	 * @deprecated since DataValues Common 0.3, just use getInstance.
@@ -27,10 +27,10 @@ class GeoCoordinateParserTest extends StringValueParserTest {
 	/**
 	 * @see ValueParserTestBase::getInstance
 	 *
-	 * @return GeoCoordinateParser
+	 * @return LatLongParser
 	 */
 	protected function getInstance() {
-		return new GeoCoordinateParser();
+		return new LatLongParser();
 	}
 
 	/**


### PR DESCRIPTION
This always bugged my. "GeoCoordinate" was the old name of the value class. It was renamed a long time ago. For some reason parser and formatter were never renamed. Why not?

This is, obviously, a breaking change.

I suggest to do this along with the "kill all aliases" patch.
