### PR TITLE
Fix broken LatLongValueTest cases

### DIFF
--- a/tests/unit/Values/LatLongValueTest.php
+++ b/tests/unit/Values/LatLongValueTest.php
@@ -47,21 +47,19 @@ class LatLongValueTest extends DataValueTest {
 	public function invalidConstructorArgumentsProvider() {
 		$argLists = array();
 
-		$argLists[] = array();
+		$argLists[] = array( null, null );
 
-		$argLists[] = array( 42 );
-		$argLists[] = array( array() );
-		$argLists[] = array( false );
-		$argLists[] = array( true );
-		$argLists[] = array( null );
-		$argLists[] = array( 'foo' );
-		$argLists[] = array( 42 );
+		$argLists[] = array( 42, null );
+		$argLists[] = array( array(), null );
+		$argLists[] = array( false, null );
+		$argLists[] = array( true, null );
+		$argLists[] = array( 'foo', null );
+		$argLists[] = array( 42, null );
 
 		$argLists[] = array( 'en', 42 );
 		$argLists[] = array( 'en', 4.2 );
 		$argLists[] = array( 42, false );
 		$argLists[] = array( 42, array() );
-		$argLists[] = array( 42, null );
 		$argLists[] = array( 42, 'foo' );
 		$argLists[] = array( 4.2, 'foo' );
 


### PR DESCRIPTION
~~These tests never made sense. The two constructor parameters are not optional. If you miss one, you don't get an exception but a runtime error instead. You can't test for runtime errors (as far as I know).~~ Wait. These are scalar parameters. You can omit them. So the question is not why the test ever worked but why it does not work any more.

This is the reason for the broken tests in #22 and #23.
