### PR TITLE
Refined precision detection

### DIFF
--- a/src/Parsers/GlobeCoordinateParser.php
+++ b/src/Parsers/GlobeCoordinateParser.php
@@ -18,6 +18,7 @@ use ValueParsers\StringValueParser;
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author H. Snater < mediawiki@snater.com >
+ * @author Thiemo Mättig
  */
 class GlobeCoordinateParser extends StringValueParser {
 
@@ -93,73 +94,39 @@ class GlobeCoordinateParser extends StringValueParser {
 	}
 
 	protected function detectDdPrecision( $degree ) {
-		// TODO: Implement localized decimal separator.
-		$split = explode( '.', $degree );
-
-		$precision = 1;
-
-		if ( isset( $split[1] ) ) {
-			$precision = pow( 10, -strlen( $split[1] ) );
-		}
-
-		return $precision;
+		return $this->detectFloatPrecision( $degree );
 	}
 
 	protected function detectDmPrecision( $degree ) {
 		$minutes = $degree * 60;
+		$split = explode( '.', round( $minutes, 6 ) );
 
-		// Since arcminutes shall be used to detect the precision, precision needs at least to be an
-		// arcminute:
-		$precision = 1 / 60;
-
-		// The minute may be a float; In order to detect a proper precision, we convert the minutes
-		// to seconds.
-		if ( $minutes - floor( $minutes ) > 0 ) {
-			$seconds = $minutes * 60;
-
-			$precision = 1 / 3600;
-
-			// TODO: Implement localized decimal separator.
-			$secondsSplit = explode( '.', $seconds );
-
-			if ( isset( $secondsSplit[1] ) ) {
-				$precision *= pow( 10, -strlen( $secondsSplit[1] ) );
-			}
+		if ( isset( $split[1] ) ) {
+			return $this->detectDmsPrecision( $degree );
 		}
 
-		return $precision;
+		return 1 / 60;
 	}
 
 	protected function detectDmsPrecision( $degree ) {
 		$seconds = $degree * 3600;
+		$split = explode( '.', round( $seconds, 4 ) );
 
-		// Since arcseconds shall be used to detect the precision, precision needs at least to be an
-		// arcsecond:
-		$precision = 1 / 3600;
-
-		if ( $degree - floor( $degree ) > 0 ) {
-			// TODO: Implement localized decimal separator.
-			$secondsSplit = explode( '.', $seconds );
-
-			if ( isset( $secondsSplit[1] ) ) {
-				$precision *= pow( 10, -strlen( $secondsSplit[1] ) );
-			}
+		if ( isset( $split[1] ) ) {
+			return pow( 10, -strlen( $split[1] ) ) / 3600;
 		}
 
-		return $precision;
+		return 1 / 3600;
 	}
 
 	protected function detectFloatPrecision( $degree ) {
-		// TODO: Implement localized decimal separator.
-		$split = explode( '.', $degree );
-
-		$precision = 1;
+		$split = explode( '.', round( $degree, 8 ) );
 
 		if ( isset( $split[1] ) ) {
-			$precision = pow( 10, -strlen( $split[1] ) );
+			return pow( 10, -strlen( $split[1] ) );
 		}
 
-		return $precision;
+		return 1;
 	}
 
 }

--- a/tests/unit/Parsers/GlobeCoordinateParserTest.php
+++ b/tests/unit/Parsers/GlobeCoordinateParserTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\DataValues\Geo\Parsers;
 
+use DataValues\Geo\Parsers\GlobeCoordinateParser;
 use DataValues\Geo\Values\GlobeCoordinateValue;
 use DataValues\Geo\Values\LatLongValue;
 use ValueParsers\ParserOptions;
@@ -16,6 +17,7 @@ use ValueParsers\Test\StringValueParserTest;
  *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author Thiemo Mättig
  */
 class GlobeCoordinateParserTest extends StringValueParserTest {
 
@@ -173,6 +175,80 @@ class GlobeCoordinateParserTest extends StringValueParserTest {
 		);
 
 		return $data;
+	}
+
+	/**
+	 * @dataProvider precisionDetectionProvider
+	 * @param string $value
+	 * @param float|int $expected
+	 */
+	public function testPrecisionDetection( $value, $expected ) {
+		$parser = new GlobeCoordinateParser();
+		/** @var GlobeCoordinateValue $globeCoordinateValue */
+		$globeCoordinateValue = $parser->parse( $value );
+
+		$this->assertSame( $expected, $globeCoordinateValue->getPrecision() );
+	}
+
+	public function precisionDetectionProvider() {
+		return array(
+			// Float
+			array( '10 20', 1 ),
+			array( '1 2', 1 ),
+			array( '1.3 2.4', 0.1 ),
+			array( '1.3 20', 0.1 ),
+			array( '10 2.4', 0.1 ),
+			array( '1.35 2.46', 0.01 ),
+			array( '1.357 2.468', 0.001 ),
+			array( '1.3579 2.468', 0.0001 ),
+			array( '1.00001 2.00001', 0.00001 ),
+			array( '1.000001 2.000001', 0.000001 ),
+			array( '1.0000001 2.0000001', 0.0000001 ),
+			array( '1.00000001 2.00000001', 0.00000001 ),
+			array( '1.000000001 2.000000001', 1 ),
+			array( '1.555555555 2.555555555', 0.00000001 ),
+
+			// Dd
+			array( '10° 20°', 1 ),
+			array( '1° 2°', 1 ),
+			array( '1.3° 2.4°', 0.1 ),
+			array( '1.3° 20°', 0.1 ),
+			array( '10° 2.4°', 0.1 ),
+			array( '1.35° 2.46°', 0.01 ),
+			array( '1.357° 2.468°', 0.001 ),
+			array( '1.3579° 2.468°', 0.0001 ),
+			array( '1.00001° 2.00001°', 0.00001 ),
+			array( '1.000001° 2.000001°', 0.000001 ),
+			array( '1.0000001° 2.0000001°', 0.0000001 ),
+			array( '1.00000001° 2.00000001°', 0.00000001 ),
+			array( '1.000000001° 2.000000001°', 1 ),
+			array( '1.555555555° 2.555555555°', 0.00000001 ),
+
+			// Dm
+			array( '1°3\' 2°4\'', 1 / 60 ),
+			array( '1°3\' 2°0\'', 1 / 60 ),
+			array( '1°0\' 2°4\'', 1 / 60 ),
+			array( '1°3.5\' 2°4.6\'', 1 / 3600 ),
+			array( '1°3.57\' 2°4.68\'', 1 / 36000 ),
+			array( '1°3.579\' 2°4.68\'', 1 / 360000 ),
+			array( '1°3.0001\' 2°4.0001\'', 1 / 3600000 ),
+			array( '1°3.00001\' 2°4.00001\'', 1 / 36000000 ),
+			array( '1°3.000001\' 2°4.000001\'', 1 / 36000000 ),
+			array( '1°3.0000001\' 2°4.0000001\'', 1 / 60 ),
+			array( '1°3.5555555\' 2°4.5555555\'', 1 / 36000000 ),
+
+			// Dms
+			array( '1°3\'5" 2°4\'6"', 1 / 3600 ),
+			array( '1°3\'5" 2°0\'0"', 1 / 3600 ),
+			array( '1°0\'0" 2°4\'6"', 1 / 3600 ),
+			array( '1°3\'0" 2°4\'0"', 1 / 3600 ),
+			array( '1°3\'5.7" 2°4\'6.8"', 1 / 36000 ),
+			array( '1°3\'5.79" 2°4\'6.8"', 1 / 360000 ),
+			array( '1°3\'5.001" 2°4\'6.001"', 1 / 3600000 ),
+			array( '1°3\'5.0001" 2°4\'6.0001"', 1 / 36000000 ),
+			array( '1°3\'5.00001" 2°4\'6.00001"', 1 / 3600 ),
+			array( '1°3\'5.55555" 2°4\'6.55555"', 1 / 36000000 ),
+		);
 	}
 
 	/**


### PR DESCRIPTION
The diff looks big because I renamed variables, made stuff private and reduced code duplication.

The main change is: The precision detection stops at a certain precision. Now there is a lower boundary, given by a maximum number of decimal places (after the comma). 8 for floats, 4 for DM/DMS (plus 2 places for the minutes and 2 for the seconds is also 8).
- 0.00000001° is approx. 1 mm.
- 1 / 36000000° is approx. 3 mm.

Reason for all this is IEEE. Some combinations of degrees and minutes turn into numbers like 1.20000000000001 and cause the detectors to return way to high precisions.

[Bug: 64820](https://bugzilla.wikimedia.org/show_bug.cgi?id=64820)
