### PR TITLE
Add edge case to GlobeCoordinateParserTest

### DIFF
--- a/tests/unit/Parsers/GlobeCoordinateParserTest.php
+++ b/tests/unit/Parsers/GlobeCoordinateParserTest.php
@@ -39,10 +39,6 @@ class GlobeCoordinateParserTest extends StringValueParserTest {
 
 	/**
 	 * @see ValueParserTestBase::validInputProvider
-	 *
-	 * @since 0.1
-	 *
-	 * @return array
 	 */
 	public function validInputProvider() {
 		$argLists = array();
@@ -127,6 +123,9 @@ class GlobeCoordinateParserTest extends StringValueParserTest {
 		return $argLists;
 	}
 
+	/**
+	 * @see StringValueParserTest::invalidInputProvider
+	 */
 	public function invalidInputProvider() {
 		$argLists = parent::invalidInputProvider();
 
@@ -195,8 +194,6 @@ class GlobeCoordinateParserTest extends StringValueParserTest {
 
 	/**
 	 * @dataProvider precisionDetectionProvider
-	 * @param string $value
-	 * @param float|int $expected
 	 */
 	public function testPrecisionDetection( $value, $expected ) {
 		$parser = new GlobeCoordinateParser();
@@ -263,6 +260,12 @@ class GlobeCoordinateParserTest extends StringValueParserTest {
 			array( '1°3\'5.0001" 2°4\'6.0001"', 1 / 36000000 ),
 			array( '1°3\'5.00001" 2°4\'6.00001"', 1 / 3600 ),
 			array( '1°3\'5.55555" 2°4\'6.55555"', 1 / 36000000 ),
+
+			/**
+			 * @fixme What do the users expect in this case, 1/3600 or 1/360000?
+			 * @see https://bugzilla.wikimedia.org/show_bug.cgi?id=64820
+			 */
+			array( '47°42\'0.00"N, 15°27\'0.00"E', 1 / 3600 ),
 		);
 	}
 


### PR DESCRIPTION
I think the current behavior is correct and should not change, but let's at least add this to the tests.

[Bug: 64820](https://bugzilla.wikimedia.org/show_bug.cgi?id=64820)