### PR TITLE
Simplify options handling

### DIFF
--- a/src/Formatters/GlobeCoordinateFormatter.php
+++ b/src/Formatters/GlobeCoordinateFormatter.php
@@ -34,7 +34,7 @@ class GlobeCoordinateFormatter extends ValueFormatterBase {
 	 */
 	public function format( $value ) {
 		if ( !( $value instanceof GlobeCoordinateValue ) ) {
-			throw new InvalidArgumentException( 'The GlobeCoordinateFormatter can only format instances of GlobeCoordinateValue.' );
+			throw new InvalidArgumentException( 'Data value type mismatch. Expected a GlobeCoordinateValue.' );
 		}
 
 		$formatter = new GeoCoordinateFormatter( $this->options );

--- a/src/Parsers/GeoCoordinateParser.php
+++ b/src/Parsers/GeoCoordinateParser.php
@@ -4,7 +4,6 @@ namespace DataValues\Geo\Parsers;
 
 use DataValues\Geo\Values\GlobeCoordinateValue;
 use ValueParsers\ParseException;
-use ValueParsers\ParserOptions;
 use ValueParsers\StringValueParser;
 
 /**
@@ -113,7 +112,7 @@ class GeoCoordinateParser extends StringValueParser {
 		static $parser = null;
 
 		if ( $parser === null ) {
-			$parser = new self( new ParserOptions() );
+			$parser = new self();
 		}
 
 		return $parser->parse( $string )->isValid();


### PR DESCRIPTION
This removes quite some obsolete code.

Originally the goal was to remove the unused newParserOptions method and to simplify the getInstance methods as much as possible. The additional changes are very closely related.