### PR TITLE
Deprecate getFormatterClass in favor of getInstance

### DIFF
--- a/tests/unit/Formatters/GlobeCoordinateFormatterTest.php
+++ b/tests/unit/Formatters/GlobeCoordinateFormatterTest.php
@@ -23,6 +23,24 @@ use ValueParsers\ParserOptions;
 class GlobeCoordinateFormatterTest extends ValueFormatterTestBase {
 
 	/**
+	 * @deprecated since 0.2, just use getInstance.
+	 */
+	protected function getFormatterClass() {
+		throw new \LogicException( 'Should not be called, use getInstance' );
+	}
+
+	/**
+	 * @see ValueFormatterTestBase::getInstance
+	 *
+	 * @param FormatterOptions|null $options
+	 *
+	 * @return GlobeCoordinateFormatter
+	 */
+	protected function getInstance( FormatterOptions $options = null ) {
+		return new GlobeCoordinateFormatter( $options );
+	}
+
+	/**
 	 * @see ValueFormatterTestBase::validProvider
 	 *
 	 * @since 0.1
@@ -98,17 +116,6 @@ class GlobeCoordinateFormatterTest extends ValueFormatterTestBase {
 		return $argLists;
 	}
 
-	/**
-	 * @see ValueFormatterTestBase::getFormatterClass
-	 *
-	 * @since 0.1
-	 *
-	 * @return string
-	 */
-	protected function getFormatterClass() {
-		return 'DataValues\Geo\Formatters\GlobeCoordinateFormatter';
-	}
-
 	public function testFormatWithInvalidPrecision_fallsBackToDefaultPrecision() {
 		$options = new FormatterOptions();
 		$options->setOption( GeoCoordinateFormatter::OPT_PRECISION, 0 );
@@ -122,7 +129,7 @@ class GlobeCoordinateFormatterTest extends ValueFormatterTestBase {
 	 * @dataProvider validProvider
 	 */
 	public function testFormatterRoundTrip( GlobeCoordinateValue $coord, $expectedValue, FormatterOptions $options )  {
-		$formatter = $this->getInstance( $options );
+		$formatter = new GlobeCoordinateFormatter( $options );
 
 		$parser = new GlobeCoordinateParser(
 			new ParserOptions( array( 'precision' => $coord->getPrecision() ) )

--- a/tests/unit/Parsers/DdCoordinateParserTest.php
+++ b/tests/unit/Parsers/DdCoordinateParserTest.php
@@ -22,7 +22,7 @@ class DdCoordinateParserTest extends StringValueParserTest {
 	 * @deprecated since 0.3, just use getInstance.
 	 */
 	protected function getParserClass() {
-		return 'DataValues\Geo\Parsers\DdCoordinateParser';
+		throw new \LogicException( 'Should not be called, use getInstance' );
 	}
 
 	/**

--- a/tests/unit/Parsers/DmCoordinateParserTest.php
+++ b/tests/unit/Parsers/DmCoordinateParserTest.php
@@ -22,7 +22,7 @@ class DmCoordinateParserTest extends StringValueParserTest {
 	 * @deprecated since 0.3, just use getInstance.
 	 */
 	protected function getParserClass() {
-		return 'DataValues\Geo\Parsers\DmCoordinateParser';
+		throw new \LogicException( 'Should not be called, use getInstance' );
 	}
 
 	/**

--- a/tests/unit/Parsers/DmsCoordinateParserTest.php
+++ b/tests/unit/Parsers/DmsCoordinateParserTest.php
@@ -22,7 +22,7 @@ class DmsCoordinateParserTest extends StringValueParserTest {
 	 * @deprecated since 0.3, just use getInstance.
 	 */
 	protected function getParserClass() {
-		return 'DataValues\Geo\Parsers\DmsCoordinateParser';
+		throw new \LogicException( 'Should not be called, use getInstance' );
 	}
 
 	/**

--- a/tests/unit/Parsers/FloatCoordinateParserTest.php
+++ b/tests/unit/Parsers/FloatCoordinateParserTest.php
@@ -22,7 +22,7 @@ class FloatCoordinateParserTest extends StringValueParserTest {
 	 * @deprecated since 0.3, just use getInstance.
 	 */
 	protected function getParserClass() {
-		return 'DataValues\Geo\Parsers\FloatCoordinateParser';
+		throw new \LogicException( 'Should not be called, use getInstance' );
 	}
 
 	/**

--- a/tests/unit/Parsers/GeoCoordinateParserTest.php
+++ b/tests/unit/Parsers/GeoCoordinateParserTest.php
@@ -22,7 +22,7 @@ class GeoCoordinateParserTest extends StringValueParserTest {
 	 * @deprecated since 0.3, just use getInstance.
 	 */
 	protected function getParserClass() {
-		return 'DataValues\Geo\Parsers\GeoCoordinateParser';
+		throw new \LogicException( 'Should not be called, use getInstance' );
 	}
 
 	/**

--- a/tests/unit/Parsers/GlobeCoordinateParserTest.php
+++ b/tests/unit/Parsers/GlobeCoordinateParserTest.php
@@ -25,7 +25,7 @@ class GlobeCoordinateParserTest extends StringValueParserTest {
 	 * @deprecated since 0.3, just use getInstance.
 	 */
 	protected function getParserClass() {
-		return 'DataValues\Geo\Parsers\GlobeCoordinateParser';
+		throw new \LogicException( 'Should not be called, use getInstance' );
 	}
 
 	/**


### PR DESCRIPTION
See https://github.com/DataValues/Interfaces/pull/9.

Bug: [T92268](https://phabricator.wikimedia.org/T92268)