### PR TITLE
Add missing type and range checks to GlobeCoordinateValue

### DIFF
--- a/src/Values/GlobeCoordinateValue.php
+++ b/src/Values/GlobeCoordinateValue.php
@@ -12,6 +12,7 @@ use DataValues\IllegalValueException;
  *
  * @license GPL-2.0+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ * @author Thiemo Mättig
  */
 class GlobeCoordinateValue extends DataValueObject {
 
@@ -46,13 +47,14 @@ class GlobeCoordinateValue extends DataValueObject {
 	 *
 	 * @throws IllegalValueException
 	 */
-	public function __construct( LatLongValue $latLong, $precision, $globe = null ) {
+	public function __construct( LatLongValue $latLong, $precision = null, $globe = null ) {
+		$this->assertIsPrecision( $precision );
+
 		if ( $globe === null ) {
 			$globe = self::GLOBE_EARTH;
+		} elseif ( !is_string( $globe ) || $globe === '' ) {
+			throw new IllegalValueException( '$globe must be a non-empty string or null' );
 		}
-
-		$this->assertIsPrecision( $precision );
-		$this->assertIsGlobe( $globe );
 
 		$this->latLong = $latLong;
 		$this->precision = $precision;
@@ -60,20 +62,20 @@ class GlobeCoordinateValue extends DataValueObject {
 	}
 
 	/**
+	 * @see LatLongValue::assertIsLatitude
+	 * @see LatLongValue::assertIsLongitude
+	 *
 	 * @param float|int|null $precision
+	 *
+	 * @throws IllegalValueException
 	 */
-	protected function assertIsPrecision( $precision ) {
-		if ( !is_null( $precision ) && !is_float( $precision ) && !is_int( $precision ) ) {
-			throw new IllegalValueException( '$precision must be a number or null' );
-		}
-	}
-
-	/**
-	 * @param string $globe
-	 */
-	protected function assertIsGlobe( $globe ) {
-		if ( !is_string( $globe ) ) {
-			throw new IllegalValueException( '$globe must be a string or null' );
+	private function assertIsPrecision( $precision ) {
+		if ( $precision !== null ) {
+			if ( !is_float( $precision ) && !is_int( $precision ) ) {
+				throw new IllegalValueException( '$precision must be a number or null' );
+			} elseif ( $precision < -360 || $precision > 360 ) {
+				throw new IllegalValueException( '$precision needs to be between -360 and 360' );
+			}
 		}
 	}
 

--- a/tests/unit/Values/GlobeCoordinateValueTest.php
+++ b/tests/unit/Values/GlobeCoordinateValueTest.php
@@ -37,6 +37,8 @@ class GlobeCoordinateValueTest extends DataValueTest {
 		$argLists[] = array( new LatLongValue( 4.2, -42 ), 0.1 );
 		$argLists[] = array( new LatLongValue( -42, 4.2 ), 10 );
 		$argLists[] = array( new LatLongValue( 0, 0 ), 0.001 );
+		$argLists[] = array( new LatLongValue( 0, 0 ), 360 );
+		$argLists[] = array( new LatLongValue( 0, 0 ), -360 );
 
 		$argLists[] = array( new LatLongValue( 4.2, 4.2 ), 1, GlobeCoordinateValue::GLOBE_EARTH );
 		$argLists[] = array( new LatLongValue( 4.2, 4.2 ), 1, 'terminus' );
@@ -51,23 +53,23 @@ class GlobeCoordinateValueTest extends DataValueTest {
 	public function invalidConstructorArgumentsProvider() {
 		$argLists = array();
 
+		$argLists[] = array( new LatLongValue( 4.2, 4.2 ), 361 );
+		$argLists[] = array( new LatLongValue( 4.2, 4.2 ), -361 );
 		$argLists[] = array( new LatLongValue( 4.2, 4.2 ), 'foo' );
 		$argLists[] = array( new LatLongValue( 4.2, 4.2 ), true );
 		$argLists[] = array( new LatLongValue( 4.2, 4.2 ), array( 1 ) );
 		$argLists[] = array( new LatLongValue( 4.2, 4.2 ), '1' );
 
+		$argLists[] = array( new LatLongValue( 4.2, 4.2 ), 1, '' );
+		$argLists[] = array( new LatLongValue( 4.2, 4.2 ), 1, true );
 		$argLists[] = array( new LatLongValue( 4.2, 4.2 ), 1, array( 1 ) );
 		$argLists[] = array( new LatLongValue( 4.2, 4.2 ), 1, 1 );
-
-		// TODO: test precisions that are out of the valid range
 
 		return $argLists;
 	}
 
 	/**
 	 * @dataProvider instanceProvider
-	 * @param GlobeCoordinateValue $globeCoordinate
-	 * @param array $arguments
 	 */
 	public function testGetLatitude( GlobeCoordinateValue $globeCoordinate, array $arguments ) {
 		$actual = $globeCoordinate->getLatitude();
@@ -78,8 +80,6 @@ class GlobeCoordinateValueTest extends DataValueTest {
 
 	/**
 	 * @dataProvider instanceProvider
-	 * @param GlobeCoordinateValue $globeCoordinate
-	 * @param array $arguments
 	 */
 	public function testGetLongitude( GlobeCoordinateValue $globeCoordinate, array $arguments ) {
 		$actual = $globeCoordinate->getLongitude();
@@ -90,8 +90,6 @@ class GlobeCoordinateValueTest extends DataValueTest {
 
 	/**
 	 * @dataProvider instanceProvider
-	 * @param GlobeCoordinateValue $globeCoordinate
-	 * @param array $arguments
 	 */
 	public function testGetPrecision( GlobeCoordinateValue $globeCoordinate, array $arguments ) {
 		$actual = $globeCoordinate->getPrecision();
@@ -105,8 +103,6 @@ class GlobeCoordinateValueTest extends DataValueTest {
 
 	/**
 	 * @dataProvider instanceProvider
-	 * @param GlobeCoordinateValue $globeCoordinate
-	 * @param array $arguments
 	 */
 	public function testGetGlobe( GlobeCoordinateValue $globeCoordinate, array $arguments ) {
 		$expected = isset( $arguments[2] )


### PR DESCRIPTION
This patch includes two relevant changes to the classes behavior:
- The precision parameter's range is checked to be between -360 and +360. This is identical to the allowed range of the coordinate itself. This partly fixes #68.
- The globe is not allowed to be an empty string any more.
