### PR TITLE
Fix format name strings in parsers

### DIFF
--- a/src/Parsers/GeoCoordinateParserBase.php
+++ b/src/Parsers/GeoCoordinateParserBase.php
@@ -16,7 +16,7 @@ use ValueParsers\StringValueParser;
  */
 abstract class GeoCoordinateParserBase extends StringValueParser {
 
-	const FORMAT_NAME = 'coordinate';
+	const FORMAT_NAME = 'geo-coordinate';
 
 	/**
 	 * The symbols representing the different directions for usage in directional notation.

--- a/src/Parsers/GlobeCoordinateParser.php
+++ b/src/Parsers/GlobeCoordinateParser.php
@@ -22,7 +22,7 @@ use ValueParsers\StringValueParser;
  */
 class GlobeCoordinateParser extends StringValueParser {
 
-	const FORMAT_NAME = 'coordinate';
+	const FORMAT_NAME = 'globe-coordinate';
 
 	const OPT_GLOBE = 'globe';
 


### PR DESCRIPTION
As far as I can tell this is **not** a breaking change. These constants are not used anywhere except for exception messages. There was quite some confusion about these constants when we introduced new parsers and renamed existing parser classes. With this patch I'm applying the most simple naming scheme: identical to the relevant part of the class name, lowercase, separated with dashes.

Please merge https://github.com/DataValues/Time/pull/97 along with this.