### PR TITLE
Code cleanup and documentation

### DIFF
--- a/Geo.php
+++ b/Geo.php
@@ -15,7 +15,7 @@ if ( defined( 'DATAVALUES_GEO_VERSION' ) ) {
 	return 1;
 }
 
-define( 'DATAVALUES_GEO_VERSION', '1.1.4' );
+define( 'DATAVALUES_GEO_VERSION', '1.1.5' );
 
 if ( defined( 'MEDIAWIKI' ) ) {
 	$GLOBALS['wgExtensionCredits']['datavalues'][] = array(

--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ It is based upon and contains a lot of code written by [Jeroen De Dauw]
 
 ## Release notes
 
+### 1.1.5 (2015-12-28)
+
+* The component can now be installed together with DataValues Interfaces 0.2.x
+
 ### 1.1.4 (2014-11-25)
 
 * Add fall back to default on invalid precision to more places.

--- a/src/Formatters/GeoCoordinateFormatter.php
+++ b/src/Formatters/GeoCoordinateFormatter.php
@@ -102,14 +102,14 @@ class GeoCoordinateFormatter extends ValueFormatterBase {
 	 *
 	 * @since 0.1
 	 *
-	 * @param LatLongValue $value The value to format
+	 * @param LatLongValue $value
 	 *
-	 * @return string
+	 * @return string Plain text
 	 * @throws InvalidArgumentException
 	 */
 	public function format( $value ) {
 		if ( !( $value instanceof LatLongValue ) ) {
-			throw new InvalidArgumentException( '$value must be a LatLongValue' );
+			throw new InvalidArgumentException( 'Data value type mismatch. Expected a LatLongValue.' );
 		}
 
 		$precision = $this->options->getOption( self::OPT_PRECISION );
@@ -125,7 +125,7 @@ class GeoCoordinateFormatter extends ValueFormatterBase {
 	 * @param LatLongValue $value
 	 * @param float $precision The desired precision, given as fractional degrees.
 	 *
-	 * @return string
+	 * @return string Plain text
 	 * @throws InvalidArgumentException
 	 */
 	public function formatLatLongValue( LatLongValue $value, $precision ) {
@@ -243,8 +243,8 @@ class GeoCoordinateFormatter extends ValueFormatterBase {
 		$isNegative = $floatDegrees < 0;
 		$floatDegrees = abs( $floatDegrees );
 
-		$degrees = floor( $floatDegrees );
-		$minutes = floor( ( $floatDegrees - $degrees ) * 60 );
+		$degrees = (int)$floatDegrees;
+		$minutes = (int)( ( $floatDegrees - $degrees ) * 60 );
 		$seconds = ( $floatDegrees - ( $degrees + $minutes / 60 ) ) * 3600;
 
 		$result = $this->formatNumber( $degrees )
@@ -275,7 +275,7 @@ class GeoCoordinateFormatter extends ValueFormatterBase {
 		$isNegative = $floatDegrees < 0;
 		$floatDegrees = abs( $floatDegrees );
 
-		$degrees = floor( $floatDegrees );
+		$degrees = (int)$floatDegrees;
 		$minutes = ( $floatDegrees - $degrees ) * 60;
 
 		$result = $this->formatNumber( $degrees )

--- a/src/Formatters/GlobeCoordinateFormatter.php
+++ b/src/Formatters/GlobeCoordinateFormatter.php
@@ -27,9 +27,9 @@ class GlobeCoordinateFormatter extends ValueFormatterBase {
 	 *
 	 * @since 0.1
 	 *
-	 * @param GlobeCoordinateValue $value The value to format
+	 * @param GlobeCoordinateValue $value
 	 *
-	 * @return string
+	 * @return string Plain text
 	 * @throws InvalidArgumentException
 	 */
 	public function format( $value ) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,4 +11,4 @@ if ( !is_readable( __DIR__ . '/../vendor/autoload.php' ) ) {
 	die( 'You need to install this package with Composer before you can run the tests' );
 }
 
-$autoLoader = require_once( __DIR__ . '/../vendor/autoload.php' );
+require_once __DIR__ . '/../vendor/autoload.php';

--- a/tests/unit/Formatters/GeoCoordinateFormatterTest.php
+++ b/tests/unit/Formatters/GeoCoordinateFormatterTest.php
@@ -370,7 +370,7 @@ class GeoCoordinateFormatterTest extends \PHPUnit_Framework_TestCase {
 
 	private function provideSpacingLevelOptions() {
 		return array(
-			'none' => array( ),
+			'none' => array(),
 			'latlong' => array( GeoCoordinateFormatter::OPT_SPACE_LATLONG ),
 			'direction' => array( GeoCoordinateFormatter::OPT_SPACE_DIRECTION ),
 			'coordparts' => array( GeoCoordinateFormatter::OPT_SPACE_COORDPARTS ),


### PR DESCRIPTION
I felt that it's not worth to split this into individual patches. This should all be obvious, with one exception: The only difference between `floor` and casting to `(int)` is that the later under/overflows on 32 bit systems. But this is not relevant here because lat/long are limited to [-360…360] degree in LatLongValue.

If you want this be split into several patches, please tell me and I will do it.