### PR TITLE
Fixups missing in release 0.1.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
 		"php": ">=5.3.0",
 		"data-values/data-values": "~1.0|~0.1",
 		"data-values/interfaces": "~0.2.0|~0.1.5",
-		"data-values/common": "~0.2.3"
+		"data-values/common": "~0.3.0|~0.2.0"
 	},
 	"autoload": {
 		"files" : [

--- a/src/Formatters/GeoCoordinateFormatter.php
+++ b/src/Formatters/GeoCoordinateFormatter.php
@@ -100,8 +100,6 @@ class GeoCoordinateFormatter extends ValueFormatterBase {
 	 *
 	 * Calls formatLatLongValue() using OPT_PRECISION for the $precision parameter.
 	 *
-	 * @since 0.1
-	 *
 	 * @param LatLongValue $value
 	 *
 	 * @return string Plain text

--- a/src/Formatters/GlobeCoordinateFormatter.php
+++ b/src/Formatters/GlobeCoordinateFormatter.php
@@ -25,8 +25,6 @@ class GlobeCoordinateFormatter extends ValueFormatterBase {
 	/**
 	 * @see ValueFormatter::format
 	 *
-	 * @since 0.1
-	 *
 	 * @param GlobeCoordinateValue $value
 	 *
 	 * @return string Plain text

--- a/tests/unit/Formatters/GlobeCoordinateFormatterTest.php
+++ b/tests/unit/Formatters/GlobeCoordinateFormatterTest.php
@@ -42,10 +42,6 @@ class GlobeCoordinateFormatterTest extends ValueFormatterTestBase {
 
 	/**
 	 * @see ValueFormatterTestBase::validProvider
-	 *
-	 * @since 0.1
-	 *
-	 * @return array
 	 */
 	public function validProvider() {
 		$floats = array(

--- a/tests/unit/Parsers/DdCoordinateParserTest.php
+++ b/tests/unit/Parsers/DdCoordinateParserTest.php
@@ -36,10 +36,6 @@ class DdCoordinateParserTest extends StringValueParserTest {
 
 	/**
 	 * @see ValueParserTestBase::validInputProvider
-	 *
-	 * @since 0.1
-	 *
-	 * @return array
 	 */
 	public function validInputProvider() {
 		$argLists = array();
@@ -75,6 +71,9 @@ class DdCoordinateParserTest extends StringValueParserTest {
 		return $argLists;
 	}
 
+	/**
+	 * @see StringValueParserTest::invalidInputProvider
+	 */
 	public function invalidInputProvider() {
 		$argLists = parent::invalidInputProvider();
 

--- a/tests/unit/Parsers/DmCoordinateParserTest.php
+++ b/tests/unit/Parsers/DmCoordinateParserTest.php
@@ -36,10 +36,6 @@ class DmCoordinateParserTest extends StringValueParserTest {
 
 	/**
 	 * @see ValueParserTestBase::validInputProvider
-	 *
-	 * @since 0.1
-	 *
-	 * @return array
 	 */
 	public function validInputProvider() {
 		$argLists = array();
@@ -75,6 +71,9 @@ class DmCoordinateParserTest extends StringValueParserTest {
 		return $argLists;
 	}
 
+	/**
+	 * @see StringValueParserTest::invalidInputProvider
+	 */
 	public function invalidInputProvider() {
 		$argLists = parent::invalidInputProvider();
 

--- a/tests/unit/Parsers/DmsCoordinateParserTest.php
+++ b/tests/unit/Parsers/DmsCoordinateParserTest.php
@@ -36,10 +36,6 @@ class DmsCoordinateParserTest extends StringValueParserTest {
 
 	/**
 	 * @see ValueParserTestBase::validInputProvider
-	 *
-	 * @since 0.1
-	 *
-	 * @return array
 	 */
 	public function validInputProvider() {
 		$argLists = array();
@@ -78,6 +74,9 @@ class DmsCoordinateParserTest extends StringValueParserTest {
 		return $argLists;
 	}
 
+	/**
+	 * @see StringValueParserTest::invalidInputProvider
+	 */
 	public function invalidInputProvider() {
 		$argLists = parent::invalidInputProvider();
 

--- a/tests/unit/Parsers/FloatCoordinateParserTest.php
+++ b/tests/unit/Parsers/FloatCoordinateParserTest.php
@@ -36,10 +36,6 @@ class FloatCoordinateParserTest extends StringValueParserTest {
 
 	/**
 	 * @see ValueParserTestBase::validInputProvider
-	 *
-	 * @since 0.1
-	 *
-	 * @return array
 	 */
 	public function validInputProvider() {
 		$argLists = array();
@@ -77,6 +73,9 @@ class FloatCoordinateParserTest extends StringValueParserTest {
 		return $argLists;
 	}
 
+	/**
+	 * @see StringValueParserTest::invalidInputProvider
+	 */
 	public function invalidInputProvider() {
 		$argLists = parent::invalidInputProvider();
 

--- a/tests/unit/Parsers/GeoCoordinateParserTest.php
+++ b/tests/unit/Parsers/GeoCoordinateParserTest.php
@@ -36,10 +36,6 @@ class GeoCoordinateParserTest extends StringValueParserTest {
 
 	/**
 	 * @see ValueParserTestBase::validInputProvider
-	 *
-	 * @since 0.1
-	 *
-	 * @return array
 	 */
 	public function validInputProvider() {
 		$argLists = array();
@@ -110,6 +106,9 @@ class GeoCoordinateParserTest extends StringValueParserTest {
 		return $argLists;
 	}
 
+	/**
+	 * @see StringValueParserTest::invalidInputProvider
+	 */
 	public function invalidInputProvider() {
 		$argLists = parent::invalidInputProvider();
 

--- a/tests/unit/Values/GlobeCoordinateValueTest.php
+++ b/tests/unit/Values/GlobeCoordinateValueTest.php
@@ -20,8 +20,6 @@ class GlobeCoordinateValueTest extends DataValueTest {
 	/**
 	 * @see DataValueTest::getClass
 	 *
-	 * @since 0.1
-	 *
 	 * @return string
 	 */
 	public function getClass() {

--- a/tests/unit/Values/LatLongValueTest.php
+++ b/tests/unit/Values/LatLongValueTest.php
@@ -19,8 +19,6 @@ class LatLongValueTest extends DataValueTest {
 	/**
 	 * @see DataValueTest::getClass
 	 *
-	 * @since 0.1
-	 *
 	 * @return string
 	 */
 	public function getClass() {


### PR DESCRIPTION
* This component is compatible with Common 0.3.x. [The breaking changes between Common 0.2.x and 0.3.x](https://github.com/DataValues/Common/compare/0.2.3...0.3.0) are not used here.
* This component is also compatible with Common 0.2.0. [The additions between Common 0.2.0 and 0.2.3](https://github.com/DataValues/Common/compare/0.2...0.2.3) are not used here.
* I'm removing a few `@since` tags from methods that implement an abstract base class and do not add information.

Also see:
* https://github.com/DataValues/Number/pull/53
* https://github.com/wmde/WikibaseDataModelSerialization/pull/183
* https://github.com/wmde/WikibaseInternalSerialization/pull/90