### PR TITLE
Do not use "static" in PHPDoc tags

### DIFF
--- a/src/Values/GlobeCoordinateValue.php
+++ b/src/Values/GlobeCoordinateValue.php
@@ -197,7 +197,7 @@ class GlobeCoordinateValue extends DataValueObject {
 	 *
 	 * @param array $data
 	 *
-	 * @return static
+	 * @return self
 	 * @throws IllegalValueException
 	 */
 	public static function newFromArray( array $data ) {

--- a/src/Values/LatLongValue.php
+++ b/src/Values/LatLongValue.php
@@ -194,7 +194,7 @@ class LatLongValue extends DataValueObject {
 	 *
 	 * @param float[] $data
 	 *
-	 * @return static
+	 * @return self
 	 */
 	public static function newFromArray( array $data ) {
 		return new static( $data['latitude'], $data['longitude'] );


### PR DESCRIPTION
`static` is not a valid type in my IDE. `self` is.