### PR TITLE
Fix type hint in LatLongValue

### DIFF
--- a/src/Values/LatLongValue.php
+++ b/src/Values/LatLongValue.php
@@ -192,7 +192,7 @@ class LatLongValue extends DataValueObject {
 	 *
 	 * @since 0.1
 	 *
-	 * @param float[] $data
+	 * @param array $data
 	 *
 	 * @return self
 	 */


### PR DESCRIPTION
This array is allowed to contain floats and ints, even mixed.