### PR TITLE
Round number to desired precision before formatting

### DIFF
--- a/src/Formatters/GeoCoordinateFormatter.php
+++ b/src/Formatters/GeoCoordinateFormatter.php
@@ -314,6 +314,7 @@ class GeoCoordinateFormatter extends ValueFormatterBase {
 	 */
 	private function formatNumber( $number, $digits = 0 ) {
 		//TODO: use NumberLocalizer
+		$number = round( $number, $digits > 0 ? $digits : 0 );
 		return sprintf( $digits > 0
 			? '%.' . (int)$digits . 'F'
 			: '%d', $number );

--- a/tests/unit/Formatters/GeoCoordinateFormatterTest.php
+++ b/tests/unit/Formatters/GeoCoordinateFormatterTest.php
@@ -182,7 +182,7 @@ class GeoCoordinateFormatterTest extends \PHPUnit_Framework_TestCase {
 			'ten minutes' => array(
 				new LatLongValue( -55.755786, 37.25633 ),
 				10.0/60,
-				'-55° 49\', 37° 19\''
+				'-55° 50\', 37° 20\''
 			),
 			'fifty minutes' => array(
 				new LatLongValue( -55.755786, 37.25633 ),


### PR DESCRIPTION
This patch prevents quirks like

> 52° 1' **12**" N, 10° 1' **11**" E

which is the result of LatLongValue(52.02, 10.02) with a precision of 0.01 (in DMS format), in this case rounding the seconds to

> 52° 1' 12" N, 10° 1' **12**" E

instead.