### PR TITLE
Fix for rounding issue when formatting whole number

### DIFF
--- a/src/Formatters/GeoCoordinateFormatter.php
+++ b/src/Formatters/GeoCoordinateFormatter.php
@@ -314,9 +314,8 @@ class GeoCoordinateFormatter extends ValueFormatterBase {
 	 */
 	private function formatNumber( $number, $digits = 0 ) {
 		//TODO: use NumberLocalizer
-		return sprintf( $digits > 0
-			? '%.' . (int)$digits . 'F'
-			: '%d', $number );
+		$digits = $digits < 0 ? 0 : $digits;
+		return sprintf( '%.' . (int)$digits . 'F', $number );
 	}
 
 }

--- a/tests/unit/Formatters/GeoCoordinateFormatterTest.php
+++ b/tests/unit/Formatters/GeoCoordinateFormatterTest.php
@@ -182,7 +182,7 @@ class GeoCoordinateFormatterTest extends \PHPUnit_Framework_TestCase {
 			'ten minutes' => array(
 				new LatLongValue( -55.755786, 37.25633 ),
 				10.0/60,
-				'-55° 49\', 37° 19\''
+				'-55° 50\', 37° 20\''
 			),
 			'fifty minutes' => array(
 				new LatLongValue( -55.755786, 37.25633 ),


### PR DESCRIPTION
The function `sprintf` discards digits after the decimal point if the format string `'%d'` is used, causing numbers like `35.999999999999` to be displayed as `35` instead of rounding it to `36`.

This results in some quirks with coordinates like `LatLongValue(52.01, 10.01)` with a precision of `0.01` (in DMS format), which would be displayed as

> 52° 0' **35**" N, 10° 0' **35**" E

but should be properly rounded and displayed as

> 52° 0' **36**" N, 10° 0' **36**" E

Another example is `LatLongValue(52.02, 10.02)` with a precision of `0.01`, which would be displayed as

> 52° 1' 12" N, 10° 1' **11**" E

but should be displayed as

> 52° 1' 12" N, 10° 1' **12**" E

This patch fixes this rounding issue by simply using the format string `'%.0F'` (0 digits after the decimal point) for whole numbers instead, in which case the number is properly rounded.