### PR TITLE
Prefer assertSame over assertEquals

### DIFF
--- a/tests/unit/Formatters/GlobeCoordinateFormatterTest.php
+++ b/tests/unit/Formatters/GlobeCoordinateFormatterTest.php
@@ -118,7 +118,7 @@ class GlobeCoordinateFormatterTest extends ValueFormatterTestBase {
 		$formatter = new GlobeCoordinateFormatter( $options );
 
 		$formatted = $formatter->format( new GlobeCoordinateValue( new LatLongValue( 1.2, 3.4 ), null ) );
-		$this->assertEquals( '1.2, 3.4', $formatted );
+		$this->assertSame( '1.2, 3.4', $formatted );
 	}
 
 	/**
@@ -141,7 +141,7 @@ class GlobeCoordinateFormatterTest extends ValueFormatterTestBase {
 		// NOTE: $parsed may be != $coord, because of rounding, so we can't compare directly.
 		$formattedParsed = $formatter->format( $parsed );
 
-		$this->assertEquals( $formatted, $formattedParsed );
+		$this->assertSame( $formatted, $formattedParsed );
 	}
 
 }

--- a/tests/unit/GlobeMathTest.php
+++ b/tests/unit/GlobeMathTest.php
@@ -43,7 +43,7 @@ class GlobeMathTest extends \PHPUnit_Framework_TestCase {
 	public function testNormalizeGlobe( $expected, $globe ) {
 		$normalized = $this->math->normalizeGlobe( $globe );
 
-		$this->assertEquals( $expected, $normalized );
+		$this->assertSame( $expected, $normalized );
 	}
 
 	public function latLongProvider() {
@@ -137,7 +137,7 @@ class GlobeMathTest extends \PHPUnit_Framework_TestCase {
 		$normalized = $this->math->normalizeGlobeCoordinate( $coordinate );
 
 		$equality = $this->equals( $expectedLatLong, $normalized->getLatLong() );
-		$this->assertEquals( $expectedEquality, $equality );
+		$this->assertSame( $expectedEquality, $equality );
 	}
 
 	/**
@@ -155,7 +155,7 @@ class GlobeMathTest extends \PHPUnit_Framework_TestCase {
 		$normalized = $this->math->normalizeGlobeLatLong( $latLong, $globe );
 
 		$equality = $this->equals( $expectedLatLong, $normalized );
-		$this->assertEquals( $expectedEquality, $equality );
+		$this->assertSame( $expectedEquality, $equality );
 	}
 
 	/**
@@ -174,7 +174,7 @@ class GlobeMathTest extends \PHPUnit_Framework_TestCase {
 		$normalized = $this->math->normalizeLatLong( $latLong, $minimumLongitude );
 
 		$equality = $this->equals( $expectedLatLong, $normalized );
-		$this->assertEquals( $expectedEquality, $equality );
+		$this->assertSame( $expectedEquality, $equality );
 	}
 
 	private function equals( LatLongValue $a, LatLongValue $b ) {

--- a/tests/unit/Values/GlobeCoordinateValueTest.php
+++ b/tests/unit/Values/GlobeCoordinateValueTest.php
@@ -73,7 +73,7 @@ class GlobeCoordinateValueTest extends DataValueTest {
 		$actual = $globeCoordinate->getLatitude();
 
 		$this->assertInternalType( 'float', $actual );
-		$this->assertEquals( $arguments[0]->getLatitude(), $actual );
+		$this->assertSame( $arguments[0]->getLatitude(), $actual );
 	}
 
 	/**
@@ -85,7 +85,7 @@ class GlobeCoordinateValueTest extends DataValueTest {
 		$actual = $globeCoordinate->getLongitude();
 
 		$this->assertInternalType( 'float', $actual );
-		$this->assertEquals( $arguments[0]->getLongitude(), $actual );
+		$this->assertSame( $arguments[0]->getLongitude(), $actual );
 	}
 
 	/**
@@ -100,7 +100,7 @@ class GlobeCoordinateValueTest extends DataValueTest {
 			is_float( $actual ) || is_int( $actual ) || $actual === null,
 			'Precision is int or float or null'
 		);
-		$this->assertEquals( $arguments[1], $actual );
+		$this->assertSame( $arguments[1], $actual );
 	}
 
 	/**
@@ -120,7 +120,7 @@ class GlobeCoordinateValueTest extends DataValueTest {
 			'getGlobe should return a string'
 		);
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertSame( $expected, $actual );
 	}
 
 	public function testArrayValueCompatibility() {
@@ -136,10 +136,10 @@ class GlobeCoordinateValueTest extends DataValueTest {
 		$arrayForm = unserialize( $serialization );
 		$globeCoordinate = GlobeCoordinateValue::newFromArray( $arrayForm );
 
-		$this->assertEquals( -4.2, $globeCoordinate->getLatitude() );
-		$this->assertEquals( 42, $globeCoordinate->getLongitude() );
-		$this->assertEquals( 0.01, $globeCoordinate->getPrecision() );
-		$this->assertEquals( 'mars', $globeCoordinate->getGlobe() );
+		$this->assertSame( -4.2, $globeCoordinate->getLatitude() );
+		$this->assertSame( 42.0, $globeCoordinate->getLongitude() );
+		$this->assertSame( 0.01, $globeCoordinate->getPrecision() );
+		$this->assertSame( 'mars', $globeCoordinate->getGlobe() );
 
 		$serialization = 'a:5:{s:8:"latitude";d:-4.2000000000000002;'
 			. 's:9:"longitude";d:-42;'
@@ -150,10 +150,10 @@ class GlobeCoordinateValueTest extends DataValueTest {
 		$arrayForm = unserialize( $serialization );
 		$globeCoordinate = GlobeCoordinateValue::newFromArray( $arrayForm );
 
-		$this->assertEquals( -4.2, $globeCoordinate->getLatitude() );
-		$this->assertEquals( -42, $globeCoordinate->getLongitude() );
-		$this->assertEquals( 1, $globeCoordinate->getPrecision() );
-		$this->assertEquals( 'http://www.wikidata.org/entity/Q2', $globeCoordinate->getGlobe() );
+		$this->assertSame( -4.2, $globeCoordinate->getLatitude() );
+		$this->assertSame( -42.0, $globeCoordinate->getLongitude() );
+		$this->assertSame( 1.0, $globeCoordinate->getPrecision() );
+		$this->assertSame( 'http://www.wikidata.org/entity/Q2', $globeCoordinate->getGlobe() );
 	}
 
 	public function testSerializeCompatibility() {
@@ -163,10 +163,10 @@ class GlobeCoordinateValueTest extends DataValueTest {
 		$globeCoordinate = unserialize( 'C:31:"DataValues\GlobeCoordinateValue":27:{[-4.2,-42,null,0.01,"mars"]}' );
 		$this->assertInstanceOf( $this->getClass(), $globeCoordinate );
 
-		$this->assertEquals( -4.2, $globeCoordinate->getLatitude() );
-		$this->assertEquals( -42, $globeCoordinate->getLongitude() );
-		$this->assertEquals( 0.01, $globeCoordinate->getPrecision() );
-		$this->assertEquals( 'mars', $globeCoordinate->getGlobe() );
+		$this->assertSame( -4.2, $globeCoordinate->getLatitude() );
+		$this->assertSame( -42.0, $globeCoordinate->getLongitude() );
+		$this->assertSame( 0.01, $globeCoordinate->getPrecision() );
+		$this->assertSame( 'mars', $globeCoordinate->getGlobe() );
 
 		$globeCoordinate = unserialize( 'C:31:"DataValues\GlobeCoordinateValue":27:{[-4.2,-42,9001,0.01,"mars"]}' );
 		$this->assertInstanceOf( $this->getClass(), $globeCoordinate );

--- a/tests/unit/Values/LatLongValueTest.php
+++ b/tests/unit/Values/LatLongValueTest.php
@@ -86,7 +86,7 @@ class LatLongValueTest extends DataValueTest {
 		$actual = $latLongValue->getLatitude();
 
 		$this->assertInternalType( 'float', $actual );
-		$this->assertEquals( (float)$arguments[0], $actual );
+		$this->assertSame( (float)$arguments[0], $actual );
 	}
 
 	/**
@@ -98,7 +98,7 @@ class LatLongValueTest extends DataValueTest {
 		$actual = $latLongValue->getLongitude();
 
 		$this->assertInternalType( 'float', $actual );
-		$this->assertEquals( (float)$arguments[1], $actual );
+		$this->assertSame( (float)$arguments[1], $actual );
 	}
 
 }


### PR DESCRIPTION
This is especially critical when numeric strings are involved, because a formatter returning an `2.0` float instead of a string will still succeed when tested with `assertEquals( '2°', $formatted )`, but should not. Preferring `assertSame` whenever possible avoids such situations.