### PR TITLE
Reduce PHPCS line length to 110

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -9,7 +9,7 @@
 
 	<rule ref="Generic.Files.LineLength">
 		<properties>
-			<property name="lineLimit" value="113" />
+			<property name="lineLimit" value="110" />
 		</properties>
 	</rule>
 

--- a/src/Values/GlobeCoordinateValue.php
+++ b/src/Values/GlobeCoordinateValue.php
@@ -58,13 +58,13 @@ class GlobeCoordinateValue extends DataValueObject {
 
 	protected function assertIsPrecision( $precision ) {
 		if ( !is_null( $precision ) && !is_float( $precision ) && !is_int( $precision ) ) {
-			throw new IllegalValueException( 'Can only construct GlobeCoordinateValue with a numeric precision or null' );
+			throw new IllegalValueException( '$precision must be a number or null' );
 		}
 	}
 
 	protected function assertIsGlobe( $globe ) {
 		if ( !is_string( $globe ) ) {
-			throw new IllegalValueException( 'Can only construct GlobeCoordinateValue with a string globe parameter' );
+			throw new IllegalValueException( '$globe must be a string or null' );
 		}
 	}
 


### PR DESCRIPTION
This also fixes one message (`null` was not mentioned) and avoids repeating the class name (tends to become a problem when renaming classes, reusing code, and such).