### PR TITLE
Add missing documentation to option constants

### DIFF
--- a/src/Formatters/GeoCoordinateFormatter.php
+++ b/src/Formatters/GeoCoordinateFormatter.php
@@ -29,6 +29,9 @@ use ValueFormatters\ValueFormatterBase;
  */
 class GeoCoordinateFormatter extends ValueFormatterBase {
 
+	/**
+	 * Output formats for use with the self::OPT_FORMAT option.
+	 */
 	const TYPE_FLOAT = 'float';
 	const TYPE_DMS = 'dms';
 	const TYPE_DM = 'dm';
@@ -51,18 +54,38 @@ class GeoCoordinateFormatter extends ValueFormatterBase {
 	const OPT_MINUTE_SYMBOL = 'minute';
 	const OPT_SECOND_SYMBOL = 'second';
 
+	/**
+	 * Flags for use with the self::OPT_SPACING_LEVEL option.
+	 */
 	const OPT_SPACE_LATLONG = 'latlong';
 	const OPT_SPACE_DIRECTION = 'direction';
 	const OPT_SPACE_COORDPARTS = 'coordparts';
 
+	/**
+	 * Option specifying the output format (also referred to as output type). Must be one of the
+	 * self::TYPE_… constants.
+	 */
 	const OPT_FORMAT = 'geoformat';
+
+	/**
+	 * Boolean option specifying if negative coordinates should have minus signs, e.g. "-1°, -2°"
+	 * (false) or cardinal directions, e.g. "1° S, 2° W" (true). Default is false.
+	 */
 	const OPT_DIRECTIONAL = 'directional';
 
+	/**
+	 * Option for the separator character between latitude and longitude. Defaults to a comma.
+	 */
 	const OPT_SEPARATOR_SYMBOL = 'separator';
+
+	/**
+	 * Option specifying the amount and position of space characters in the output. Must be an array
+	 * containing zero or more of the self::OPT_SPACE_… flags.
+	 */
 	const OPT_SPACING_LEVEL = 'spacing';
 
 	/**
-	 * Precision, in fractional degrees
+	 * Option specifying the precision in fractional degrees. Must be a number or numeric string.
 	 */
 	const OPT_PRECISION = 'precision';
 

--- a/src/Parsers/GlobeCoordinateParser.php
+++ b/src/Parsers/GlobeCoordinateParser.php
@@ -24,6 +24,10 @@ class GlobeCoordinateParser extends StringValueParser {
 
 	const FORMAT_NAME = 'globe-coordinate';
 
+	/**
+	 * Option specifying the globe. Should be a string containing a Wikidata concept URI. Defaults
+	 * to Earth.
+	 */
 	const OPT_GLOBE = 'globe';
 
 	/**
@@ -54,7 +58,7 @@ class GlobeCoordinateParser extends StringValueParser {
 						$latLong->getLongitude()
 					),
 					$this->detectPrecision( $latLong, $precisionDetector ),
-					$this->getOption( 'globe' )
+					$this->getOption( self::OPT_GLOBE )
 				);
 			} catch ( ParseException $parseException ) {
 				continue;

--- a/src/Values/GlobeCoordinateValue.php
+++ b/src/Values/GlobeCoordinateValue.php
@@ -34,6 +34,9 @@ class GlobeCoordinateValue extends DataValueObject {
 	 */
 	private $globe;
 
+	/**
+	 * Wikidata concept URI for the Earth. Used as default value when no other globe was specified.
+	 */
 	const GLOBE_EARTH = 'http://www.wikidata.org/entity/Q2';
 
 	/**

--- a/tests/unit/Formatters/GeoCoordinateFormatterTest.php
+++ b/tests/unit/Formatters/GeoCoordinateFormatterTest.php
@@ -78,6 +78,11 @@ class GeoCoordinateFormatterTest extends \PHPUnit_Framework_TestCase {
 				0.1,
 				'-0.1, 0.1'
 			),
+			'precision option must support strings' => array(
+				new LatLongValue( -0.05, 0.05 ),
+				'0.1',
+				'-0.1, 0.1'
+			),
 		);
 	}
 
@@ -161,6 +166,11 @@ class GeoCoordinateFormatterTest extends \PHPUnit_Framework_TestCase {
 			'rounding fractions up' => array(
 				new LatLongValue( -0.05, 0.05 ),
 				0.1,
+				'-0.1°, 0.1°'
+			),
+			'precision option must support strings' => array(
+				new LatLongValue( -0.05, 0.05 ),
+				'0.1',
 				'-0.1°, 0.1°'
 			),
 		);
@@ -258,6 +268,11 @@ class GeoCoordinateFormatterTest extends \PHPUnit_Framework_TestCase {
 				new LatLongValue( -0.05 / 60, 0.05 / 60 ),
 				0.1 / 60,
 				'-0° 0.1\', 0° 0.1\''
+			),
+			'precision option must support strings' => array(
+				new LatLongValue( -0.05, 0.05 ),
+				'0.1',
+				'-0° 6\', 0° 6\''
 			),
 		);
 	}
@@ -369,6 +384,11 @@ class GeoCoordinateFormatterTest extends \PHPUnit_Framework_TestCase {
 				new LatLongValue( -0.05 / 3600, 0.05 / 3600 ),
 				0.1 / 3600,
 				'-0° 0\' 0.1", 0° 0\' 0.1"'
+			),
+			'precision option must support strings' => array(
+				new LatLongValue( -0.05, 0.05 ),
+				'0.1',
+				'-0° 6\', 0° 6\''
 			),
 		);
 	}


### PR DESCRIPTION
This also adds tests to the formatter to make sure it accepts numeric strings in the precision option.