### PR TITLE
Fix bad formatting with 60 seconds

### DIFF
--- a/src/Formatters/GeoCoordinateFormatter.php
+++ b/src/Formatters/GeoCoordinateFormatter.php
@@ -316,11 +316,12 @@ class GeoCoordinateFormatter extends ValueFormatterBase {
 	 */
 	private function getInDegreeMinuteSecondFormat( $floatDegrees, $precision ) {
 		$isNegative = $floatDegrees < 0;
-		$floatDegrees = abs( $floatDegrees );
-
-		$degrees = (int)$floatDegrees;
-		$minutes = (int)( ( $floatDegrees - $degrees ) * 60 );
-		$seconds = ( $floatDegrees - ( $degrees + $minutes / 60 ) ) * 3600;
+		$secondDigits = $this->getSignificantDigits( 3600, $precision );
+		$seconds = round( abs( $floatDegrees ) * 3600, max( 0, $secondDigits ) );
+		$minutes = (int)( $seconds / 60 );
+		$seconds -= $minutes * 60;
+		$degrees = (int)( $minutes / 60 );
+		$minutes -= $degrees * 60;
 
 		$result = $this->formatNumber( $degrees )
 			. $this->options->getOption( self::OPT_DEGREE_SYMBOL );
@@ -332,8 +333,6 @@ class GeoCoordinateFormatter extends ValueFormatterBase {
 		}
 
 		if ( $precision < 1 / 60 ) {
-			$secondDigits = $this->getSignificantDigits( 60 * 60, $precision );
-
 			$result .= $this->getSpacing( self::OPT_SPACE_COORDPARTS )
 				. $this->formatNumber( $seconds, $secondDigits )
 				. $this->options->getOption( self::OPT_SECOND_SYMBOL );

--- a/tests/unit/Formatters/GeoCoordinateFormatterTest.php
+++ b/tests/unit/Formatters/GeoCoordinateFormatterTest.php
@@ -366,6 +366,11 @@ class GeoCoordinateFormatterTest extends \PHPUnit_Framework_TestCase {
 				0.01,
 				'52° 1\' 12", 10° 1\' 12"'
 			),
+			'degree/1000' => array(
+				new LatLongValue( 52.4, 6.7667 ),
+				0.001,
+				'52° 24\' 0", 6° 46\' 1"'
+			),
 			'ten degrees' => array(
 				new LatLongValue( -55.755786, 37.25633 ),
 				10,


### PR DESCRIPTION
Reported here: https://www.wikidata.org/wiki/Property_talk:P625#Why_is_60_seconds_possible.3F

[Bug: T153429](https://phabricator.wikimedia.org/T153429)