### PR TITLE
Round up in GeoCoordinateFormatter when close to a degree/minute

### DIFF
--- a/src/Formatters/GeoCoordinateFormatter.php
+++ b/src/Formatters/GeoCoordinateFormatter.php
@@ -254,6 +254,14 @@ class GeoCoordinateFormatter extends ValueFormatterBase {
 			return $this->getInFloatFormat( $degrees );
 		}
 
+		if ( $format !== self::TYPE_DD ) {
+			if ( $precision >= 1 - 1 / 60 && $precision < 1 ) {
+				$precision = 1;
+			} elseif ( $precision >= 1 / 60 - 1 / 3600 && $precision < 1 / 60 ) {
+				$precision = 1 / 60;
+			}
+		}
+
 		if ( $format === self::TYPE_DD || $precision >= 1 ) {
 			return $this->getInDecimalDegreeFormat( $degrees, $precision );
 		}
@@ -321,9 +329,11 @@ class GeoCoordinateFormatter extends ValueFormatterBase {
 	private function getInDegreeMinuteSecondFormat( $floatDegrees, $precision ) {
 		$isNegative = $floatDegrees < 0;
 		$secondDigits = $this->getSignificantDigits( 3600, $precision );
+
 		$seconds = round( abs( $floatDegrees ) * 3600, max( 0, $secondDigits ) );
 		$minutes = (int)( $seconds / 60 );
 		$degrees = (int)( $minutes / 60 );
+
 		$seconds -= $minutes * 60;
 		$minutes -= $degrees * 60;
 
@@ -353,8 +363,10 @@ class GeoCoordinateFormatter extends ValueFormatterBase {
 	private function getInDecimalMinuteFormat( $floatDegrees, $precision ) {
 		$isNegative = $floatDegrees < 0;
 		$minuteDigits = $this->getSignificantDigits( 60, $precision );
+
 		$minutes = round( abs( $floatDegrees ) * 60, max( 0, $minuteDigits ) );
 		$degrees = (int)( $minutes / 60 );
+
 		$minutes -= $degrees * 60;
 
 		$space = $this->getSpacing( self::OPT_SPACE_COORDPARTS );

--- a/tests/unit/Formatters/GeoCoordinateFormatterTest.php
+++ b/tests/unit/Formatters/GeoCoordinateFormatterTest.php
@@ -275,6 +275,16 @@ class GeoCoordinateFormatterTest extends \PHPUnit_Framework_TestCase {
 				0.1 / 60,
 				'-0° 0.1\', 0° 0.1\''
 			),
+			'round to degree when it does not make a difference' => array(
+				new LatLongValue( 1.5, 2.5 ),
+				1 - 1 / 60,
+				'2°, 3°'
+			),
+			'round to minutes when it starts making a difference' => array(
+				new LatLongValue( 1.5, 2.5 ),
+				1 - 2 / 60,
+				'1° 56\', 2° 54\''
+			),
 			'precision option must support strings' => array(
 				new LatLongValue( -0.05, 0.05 ),
 				'0.1',
@@ -395,6 +405,26 @@ class GeoCoordinateFormatterTest extends \PHPUnit_Framework_TestCase {
 				new LatLongValue( -0.05 / 3600, 0.05 / 3600 ),
 				0.1 / 3600,
 				'-0° 0\' 0.1", 0° 0\' 0.1"'
+			),
+			'round to degree when it does not make a difference' => array(
+				new LatLongValue( 1.5, 2.5 ),
+				1 - 1 / 60,
+				'2°, 3°'
+			),
+			'round to minutes when it starts making a difference' => array(
+				new LatLongValue( 1.5, 2.5 ),
+				1 - 2 / 60,
+				'1° 56\', 2° 54\''
+			),
+			'round to minutes when it does not make a difference' => array(
+				new LatLongValue( 1.926, 2.926 ),
+				1 / 60 - 1 / 3600,
+				'1° 56\', 2° 56\''
+			),
+			'round to seconds when it starts making a difference' => array(
+				new LatLongValue( 1.926, 2.926 ),
+				1 / 60 - 2 / 3600,
+				'1° 56\' 0", 2° 55\' 56"'
 			),
 			'unexpected rounding to 36°, 36°' => array(
 				new LatLongValue( 36.5867, 37.0458 ),


### PR DESCRIPTION
I'm introducing a delta here.
* In the degree-minute format the minute is not shown (but rounded up to degree) when the precision is *almost* 1 degree, just 1 minute lower.
* In the degree-minute-second format the second is not shown (but rounded up to minute) when the precision is *almost* 1 minute, just 1 second lower.

This compensates for all kinds of rounding errors that can happen when the precision is calculated externally.

I consider this a bugfix because it changes the output of the formatter to be *much* closer to the users expectation. When the precision is 0.999° it is very surprising to get 1°59'. This makes it look like the precision is 1 second, when in reality it is almost exactly 1 minute.

I was playing around with different thresholds. Note that 30 seconds is a bad threshold. It appears like this will create a situation where the distance to 1 minute is the same as the distance to 1 second. In reality the threshold represents 0.5 minutes, but 30 seconds (2 vs. 30 times).

A perfect threshold would be the square root of 60 = 7.746 seconds, but that would be confusing for users. 10 seconds (represents an actual digit in the output format) would be to much. Something like 5 or 2 seconds would be ok but still be confusing. So I decided to go for 1.

[Bug: T158772](https://phabricator.wikimedia.org/T158772)