### PR TITLE
Fix bad rounding of the DMS and DM formatters

### DIFF
--- a/tests/unit/Formatters/GeoCoordinateFormatterTest.php
+++ b/tests/unit/Formatters/GeoCoordinateFormatterTest.php
@@ -396,6 +396,11 @@ class GeoCoordinateFormatterTest extends \PHPUnit_Framework_TestCase {
 				0.1 / 3600,
 				'-0° 0\' 0.1", 0° 0\' 0.1"'
 			),
+			'unexpected rounding to 36°, 36°' => array(
+				new LatLongValue( 36.5867, 37.0458 ),
+				1.1187604885913,
+				'37°, 37°'
+			),
 			'precision option must support strings' => array(
 				new LatLongValue( -0.05, 0.05 ),
 				'0.1',


### PR DESCRIPTION
This patch looks bigger than it is. In essence it does one thing: Before the `getInDegreeMinuteSecondFormat` method tried to render either DMS or DM or D format, depending on the precision. Now `getInDegreeMinuteSecondFormat` is only called if the precision matches, otherwise the DM or D code path is called.

[Bug: T158772](https://phabricator.wikimedia.org/T158772)