### PR TITLE
Override getHash in GlobeCoordinateValue

### DIFF
--- a/src/Values/GlobeCoordinateValue.php
+++ b/src/Values/GlobeCoordinateValue.php
@@ -175,6 +175,18 @@ class GlobeCoordinateValue extends DataValueObject {
 	}
 
 	/**
+	 * @see Hashable::getHash
+	 *
+	 * @return string
+	 */
+	public function getHash() {
+		return md5( $this->latLong->getLatitude() . '|'
+			. $this->latLong->getLongitude() . '|'
+			. $this->precision . '|'
+			. $this->globe );
+	}
+
+	/**
 	 * @see DataValue::getArrayValue
 	 *
 	 * @return array

--- a/tests/unit/Values/GlobeCoordinateValueTest.php
+++ b/tests/unit/Values/GlobeCoordinateValueTest.php
@@ -177,7 +177,7 @@ class GlobeCoordinateValueTest extends DataValueTest {
 
 		$globeCoordinateValue = new GlobeCoordinateValue( $latLongValue, 0.1, 'does not matter' );
 
-		$this->assertEquals( '6cb12c61f8d4dce378b0e079aac2c780', $globeCoordinateValue->getHash() );
+		$this->assertEquals( '08a33f1bbb4c8bd91b6531b5bffd91fd', $globeCoordinateValue->getHash() );
 	}
 
 }


### PR DESCRIPTION
This make this getHash implementation stop relying on `serialize()`. All floats are turned into strings before calculating the hash. I kept the MD5 hash on purpose to not introduce an unexpected change to the length of this hash. We could also use a truncated SHA1, if you think this is better.

@bekh6ex, can you please try if this succeeds on all platforms? I hope it does.

[Bug: T161231](https://phabricator.wikimedia.org/T161231)