### PR TITLE
More strict version number range for MediaWiki CodeSniffer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
 		"data-values/common": "~0.3.0|~0.2.0"
 	},
 	"require-dev": {
-		"mediawiki/mediawiki-codesniffer": "~0.5",
+		"mediawiki/mediawiki-codesniffer": ">=0.4 <0.8",
 		"phpunit/phpunit": "~4.8"
 	},
 	"autoload": {


### PR DESCRIPTION
This is now the same as in Wikibase.git. We do not want this to automatically pull in currently unreleased versions that might contain breaking changes (0.8, 0.9, and so on).