### PR TITLE
Release 2.0.0

### DIFF
--- a/Geo.php
+++ b/Geo.php
@@ -15,7 +15,7 @@ if ( defined( 'DATAVALUES_GEO_VERSION' ) ) {
 	return 1;
 }
 
-define( 'DATAVALUES_GEO_VERSION', '1.2.2' );
+define( 'DATAVALUES_GEO_VERSION', '2.0.0' );
 
 if ( defined( 'MEDIAWIKI' ) ) {
 	$GLOBALS['wgExtensionCredits']['datavalues'][] = array(

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ It is based upon and contains a lot of code written by [Jeroen De Dauw]
 * Renamed `GeoCoordinateFormatter` to `LatLongFormatter`, leaving a deprecated alias.
 * Renamed `GeoCoordinateParser` to `LatLongParser`, leaving a deprecated alias.
 * Renamed `GeoCoordinateParserBase` to `LatLongParserBase`.
+* Deprecated `LatLongParser::areCoordinates`.
 
 ### 1.2.2 (2017-03-14)
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ It is based upon and contains a lot of code written by [Jeroen De Dauw]
 
 ## Release notes
 
-### 2.0.0 (2017-05-08)
+### 2.0.0 (2017-05-09)
 
 * `GlobeCoordinateValue` does not accept empty strings as globes any more.
 * `GlobeCoordinateValue` does not accept precisions outside the [-360..+360] interval any more.

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ It is based upon and contains a lot of code written by [Jeroen De Dauw]
 
 * `GlobeCoordinateValue` does not accept empty strings as globes any more.
 * `GlobeCoordinateValue` does not accept precisions outside the [-360..+360] interval any more.
-* Changed hash calculation of `GlobeCoordinateValue` to be more robust.
+* Changed hash calculation of `GlobeCoordinateValue` in an incompatible way.
 * Renamed `GeoCoordinateFormatter` to `LatLongFormatter`, leaving a deprecated alias.
 * Renamed `GeoCoordinateParser` to `LatLongParser`, leaving a deprecated alias.
 * Renamed `GeoCoordinateParserBase` to `LatLongParserBase`.

--- a/README.md
+++ b/README.md
@@ -93,8 +93,11 @@ It is based upon and contains a lot of code written by [Jeroen De Dauw]
 
 ## Release notes
 
-### 2.0.0 (dev)
+### 2.0.0 (2017-05-08)
 
+* `GlobeCoordinateValue` does not accept empty strings as globes any more.
+* `GlobeCoordinateValue` does not accept precisions outside the [-360..+360] interval any more.
+* Changed hash calculation of `GlobeCoordinateValue` to be more robust.
 * Renamed `GeoCoordinateFormatter` to `LatLongFormatter`, leaving a deprecated alias.
 * Renamed `GeoCoordinateParser` to `LatLongParser`, leaving a deprecated alias.
 * Renamed `GeoCoordinateParserBase` to `LatLongParserBase`.

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "1.2.x-dev"
+			"dev-master": "2.0.x-dev"
 		}
 	},
 	"scripts": {

--- a/src/Values/GlobeCoordinateValue.php
+++ b/src/Values/GlobeCoordinateValue.php
@@ -179,6 +179,8 @@ class GlobeCoordinateValue extends DataValueObject {
 	/**
 	 * @see Hashable::getHash
 	 *
+	 * @since 2.0
+	 *
 	 * @return string
 	 */
 	public function getHash() {


### PR DESCRIPTION
Please have a look [at the 2.0.0 milestone](https://github.com/DataValues/Geo/milestone/2). Because we changed a hash calculation in an incompatible way, we need to do a major version bump anyway. We might as well include all previously proposed breaking changes.