### PR TITLE
Remove long deprecated class aliases

### DIFF
--- a/Aliases.php
+++ b/Aliases.php
@@ -10,25 +10,6 @@ namespace {
 
 }
 
-namespace DataValues {
-
-	/**
-	 * @since 0.1
-	 * @deprecated since 1.0, use the base class instead.
-	 */
-	class LatLongValue extends \DataValues\Geo\Values\LatLongValue {
-	}
-
-	/**
-	 * @since 0.1
-	 * @deprecated since 1.0, use the base class instead.
-	 * @codingStandardsIgnoreStart
-	 */
-	class GlobeCoordinateValue extends \DataValues\Geo\Values\GlobeCoordinateValue {
-	}
-
-}
-
 namespace DataValues\Geo\Formatters {
 
 	/**
@@ -45,6 +26,7 @@ namespace DataValues\Geo\Parsers {
 	/**
 	 * @since 1.0
 	 * @deprecated since 2.0, use the base class instead.
+	 * @codingStandardsIgnoreStart
 	 */
 	class GeoCoordinateParser extends \DataValues\Geo\Parsers\LatLongParser {
 	}

--- a/Geo.php
+++ b/Geo.php
@@ -15,11 +15,7 @@ if ( defined( 'DATAVALUES_GEO_VERSION' ) ) {
 	return 1;
 }
 
-define( 'DATAVALUES_GEO_VERSION', '2.1.1' );
-
-// Aliases introduced in 1.0
-class_alias( DataValues\Geo\Values\LatLongValue::class, 'DataValues\LatLongValue' );
-class_alias( DataValues\Geo\Values\GlobeCoordinateValue::class, 'DataValues\GlobeCoordinateValue' );
+define( 'DATAVALUES_GEO_VERSION', '3.0.0' );
 
 // Aliases introduced in 2.0
 class_alias(

--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ It is based upon and contains a lot of code written by [Jeroen De Dauw]
 
 ## Release notes
 
+### 3.0.0 (dev)
+
+* Removed long deprecated class aliases `DataValues\GlobeCoordinateValue` and
+  `DataValues\LatLongValue`.
+
 ### 2.1.1 (2017-08-09)
 
 * Allow use with ~0.4.0 of DataValues/Common

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "2.0.x-dev"
+			"dev-master": "3.0.x-dev"
 		}
 	},
 	"scripts": {

--- a/tests/unit/Values/GlobeCoordinateValueTest.php
+++ b/tests/unit/Values/GlobeCoordinateValueTest.php
@@ -175,7 +175,9 @@ class GlobeCoordinateValueTest extends DataValueTest {
 		// These serializations where generated using revision f91f65f989cc3ffacbe924012d8f5b574e0b710c
 		// The strings are the result of feeding the objects directly into PHPs serialize method.
 
-		$globeCoordinate = unserialize( 'C:31:"DataValues\GlobeCoordinateValue":27:{[-4.2,-42,null,0.01,"mars"]}' );
+		$globeCoordinate = unserialize(
+			'C:42:"DataValues\Geo\Values\GlobeCoordinateValue":27:{[-4.2,-42,null,0.01,"mars"]}'
+		);
 		$this->assertInstanceOf( $this->getClass(), $globeCoordinate );
 
 		$this->assertSame( -4.2, $globeCoordinate->getLatitude() );
@@ -183,7 +185,9 @@ class GlobeCoordinateValueTest extends DataValueTest {
 		$this->assertSame( 0.01, $globeCoordinate->getPrecision() );
 		$this->assertSame( 'mars', $globeCoordinate->getGlobe() );
 
-		$globeCoordinate = unserialize( 'C:31:"DataValues\GlobeCoordinateValue":27:{[-4.2,-42,9001,0.01,"mars"]}' );
+		$globeCoordinate = unserialize(
+			'C:42:"DataValues\Geo\Values\GlobeCoordinateValue":27:{[-4.2,-42,9001,0.01,"mars"]}'
+		);
 		$this->assertInstanceOf( $this->getClass(), $globeCoordinate );
 	}
 


### PR DESCRIPTION
As discussed in #23. I confirmed (again) these [are unused](https://github.com/search?utf8=%E2%9C%93&q=%22DataValues%5CLatLongValue%22&type=Code).