### PR TITLE
Deprecate LatLongParser::areCoordinates

### DIFF
--- a/src/Parsers/LatLongParser.php
+++ b/src/Parsers/LatLongParser.php
@@ -102,6 +102,7 @@ class LatLongParser extends StringValueParser {
 	 * Analogous to creating an instance of the parser, parsing the string and checking isValid on the result.
 	 *
 	 * @since 0.1
+	 * @deprecated since 2.0, please instantiate and call isValid() instead
 	 *
 	 * @param string $string
 	 *


### PR DESCRIPTION
Fixes #108.

Unused in code relevant for Wikibase. I'm not removing the method right away because it may be used in other projects.