### PR TITLE
Never loose more than one degree precision while rounding

### DIFF
--- a/src/Formatters/LatLongFormatter.php
+++ b/src/Formatters/LatLongFormatter.php
@@ -147,6 +147,8 @@ class LatLongFormatter extends ValueFormatterBase {
 	public function formatLatLongValue( LatLongValue $value, $precision ) {
 		if ( $precision <= 0 || !is_finite( $precision ) ) {
 			$precision = 1 / 3600;
+		} elseif ( $precision > 1 ) {
+			$precision = 1;
 		}
 
 		$formatted = implode(

--- a/tests/unit/Formatters/LatLongFormatterTest.php
+++ b/tests/unit/Formatters/LatLongFormatterTest.php
@@ -47,27 +47,27 @@ class LatLongFormatterTest extends \PHPUnit_Framework_TestCase {
 			'three degrees' => [
 				new LatLongValue( -55.755786, 37.25633 ),
 				3,
-				'-57, 36'
+				'-56, 37'
 			],
 			'seven degrees' => [
 				new LatLongValue( -55.755786, 37.25633 ),
 				7,
-				'-56, 35'
+				'-56, 37'
 			],
 			'ten degrees' => [
 				new LatLongValue( -55.755786, 37.25633 ),
 				10,
-				'-60, 40'
+				'-56, 37'
 			],
 			'rounding degrees down' => [
-				new LatLongValue( -14.9, 14.9 ),
+				new LatLongValue( -10.49, 10.49 ),
 				10,
 				'-10, 10'
 			],
 			'rounding degrees up' => [
-				new LatLongValue( -15, 15 ),
+				new LatLongValue( -10.5, 10.5 ),
 				10,
-				'-20, 20'
+				'-11, 11'
 			],
 			'rounding fractions down' => [
 				new LatLongValue( -0.049, 0.049 ),
@@ -143,27 +143,27 @@ class LatLongFormatterTest extends \PHPUnit_Framework_TestCase {
 			'three degrees' => [
 				new LatLongValue( -55.755786, 37.25633 ),
 				3,
-				'-57°, 36°'
+				'-56°, 37°'
 			],
 			'seven degrees' => [
 				new LatLongValue( -55.755786, 37.25633 ),
 				7,
-				'-56°, 35°'
+				'-56°, 37°'
 			],
 			'ten degrees' => [
 				new LatLongValue( -55.755786, 37.25633 ),
 				10,
-				'-60°, 40°'
+				'-56°, 37°'
 			],
 			'rounding degrees down' => [
-				new LatLongValue( -14.9, 14.9 ),
+				new LatLongValue( -10.49, 10.49 ),
 				10,
 				'-10°, 10°'
 			],
 			'rounding degrees up' => [
-				new LatLongValue( -15, 15 ),
+				new LatLongValue( -10.5, 10.5 ),
 				10,
-				'-20°, 20°'
+				'-11°, 11°'
 			],
 			'rounding fractions down' => [
 				new LatLongValue( -0.049, 0.049 ),
@@ -254,7 +254,7 @@ class LatLongFormatterTest extends \PHPUnit_Framework_TestCase {
 			'ten degrees' => [
 				new LatLongValue( -55.755786, 37.25633 ),
 				10,
-				'-60°, 40°'
+				'-56°, 37°'
 			],
 			'rounding minutes down' => [
 				new LatLongValue( -14.9 / 60, 14.9 / 60 ),
@@ -385,7 +385,12 @@ class LatLongFormatterTest extends \PHPUnit_Framework_TestCase {
 			'ten degrees' => [
 				new LatLongValue( -55.755786, 37.25633 ),
 				10,
-				'-60°, 40°'
+				'-56°, 37°'
+			],
+			'180 degrees' => [
+				new LatLongValue( 42.1206, 2.76944 ),
+				180,
+				'42°, 3°'
 			],
 			'rounding seconds down' => [
 				new LatLongValue( -14.9 / 3600, 14.9 / 3600 ),


### PR DESCRIPTION
The immediate need that motivates this change are real-world use-cases with very large precisions (sometimes larger than the latitude and longitude values):
1. If a mistake is made and a user submits "100" (via the API), thinking it means "meters", the latitude and longitude are cut off (I would not call this "rounding") to multiples of 100, often leaving nothing but "0° N, 0° E".
2. If a user picks a coordinate to represent an entire continent on a map and purposely sets the precision to a value that is suitable for a continent, the latitude and longitude he picked are not respected but arbitrarily cut off. Let's say he picked a commonly accepted [geographical midpoint of Europe](https://en.wikipedia.org/wiki/Geographical_midpoint_of_Europe), but sets the precision to e.g. 20°, what he originally entered is disrespected and changed to [something weird about a thousand kilometers off](https://tools.wmflabs.org/geohack/geohack.php?params=60_N_20_E).

I considered limiting the precision to 10°, but decided to go with 1°. One degree represents about 100 km. I hope everybody seeing a value like "53° N, 23° E" is clever enough to understand this is so vague that it can never be confused with an exact position. Applying more rounding does not make this more obvious, especially because the current algorithm does not work in steps of 10.

I hope we can discuss and decide on this during engineering time.