### PR TITLE
Remove bad array type hint from …::newFromArray constructors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: trusty
+
 php:
   - 5.5
   - 5.6

--- a/Geo.php
+++ b/Geo.php
@@ -15,7 +15,7 @@ if ( defined( 'DATAVALUES_GEO_VERSION' ) ) {
 	return 1;
 }
 
-define( 'DATAVALUES_GEO_VERSION', '2.0.0' );
+define( 'DATAVALUES_GEO_VERSION', '2.0.1' );
 
 if ( defined( 'MEDIAWIKI' ) ) {
 	$GLOBALS['wgExtensionCredits']['datavalues'][] = array(

--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ It is based upon and contains a lot of code written by [Jeroen De Dauw]
 
 ## Release notes
 
+### 2.0.1 (2017-06-23)
+
+* Fixed `GlobeCoordinateValue::newFromArray` and `LatLongValue::newFromArray` not accepting mixed
+  values.
+* Updated minimal required PHP version from 5.3 to 5.5.9.
+
 ### 2.0.0 (2017-05-09)
 
 * `GlobeCoordinateValue` does not accept empty strings as globes any more.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ It is based upon and contains a lot of code written by [Jeroen De Dauw]
 
 ## Release notes
 
-### 2.0.1 (2017-06-23)
+### 2.0.1 (2017-06-26)
 
 * Fixed `GlobeCoordinateValue::newFromArray` and `LatLongValue::newFromArray` not accepting mixed
   values.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ It is based upon and contains a lot of code written by [Jeroen De Dauw]
 
 * Fixed `GlobeCoordinateValue::newFromArray` and `LatLongValue::newFromArray` not accepting mixed
   values.
+* Deprecated `GlobeCoordinateValue::newFromArray` and `LatLongValue::newFromArray`.
 * Updated minimal required PHP version from 5.3 to 5.5.9.
 
 ### 2.0.0 (2017-05-09)

--- a/composer.json
+++ b/composer.json
@@ -54,10 +54,10 @@
 	"scripts": {
 		"test": [
 			"@validate --no-interaction",
-			"vendor/bin/phpunit"
+			"phpunit"
 		],
 		"phpcs": [
-			"vendor/bin/phpcs src/* tests/* --standard=phpcs.xml -sp"
+			"phpcs src/* tests/* --standard=phpcs.xml -sp"
 		]
 	}
 }

--- a/src/Values/GlobeCoordinateValue.php
+++ b/src/Values/GlobeCoordinateValue.php
@@ -119,8 +119,6 @@ class GlobeCoordinateValue extends DataValueObject {
 	}
 
 	/**
-	 * @since 0.1
-	 *
 	 * @return float
 	 */
 	public function getLatitude() {
@@ -128,8 +126,6 @@ class GlobeCoordinateValue extends DataValueObject {
 	}
 
 	/**
-	 * @since 0.1
-	 *
 	 * @return float
 	 */
 	public function getLongitude() {
@@ -146,8 +142,6 @@ class GlobeCoordinateValue extends DataValueObject {
 	}
 
 	/**
-	 * @since 0.1
-	 *
 	 * @return LatLongValue
 	 */
 	public function getLatLong() {
@@ -157,8 +151,6 @@ class GlobeCoordinateValue extends DataValueObject {
 	/**
 	 * Returns the precision of the coordinate in degrees, e.g. 0.01.
 	 *
-	 * @since 0.1
-	 *
 	 * @return float|int|null
 	 */
 	public function getPrecision() {
@@ -167,8 +159,6 @@ class GlobeCoordinateValue extends DataValueObject {
 
 	/**
 	 * Returns the IRI of the globe on which the location resides.
-	 *
-	 * @since 0.1
 	 *
 	 * @return string
 	 */
@@ -210,17 +200,22 @@ class GlobeCoordinateValue extends DataValueObject {
 	}
 
 	/**
-	 * Constructs a new instance of the DataValue from the provided data.
-	 * This can round-trip with @see getArrayValue
+	 * Constructs a new instance from the provided data. Required for @see DataValueDeserializer.
+	 * This is expected to round-trip with @see getArrayValue.
 	 *
-	 * @since 0.1
+	 * @deprecated since 2.0.1. Static DataValue::newFromArray constructors like this are
+	 *  underspecified (not in the DataValue interface), and misleadingly named (should be named
+	 *  newFromArrayValue). Instead, use DataValue builder callbacks in @see DataValueDeserializer.
 	 *
-	 * @param array $data
+	 * @param mixed $data Warning! Even if this is expected to be a value as returned by
+	 *  @see getArrayValue, callers of this specific newFromArray implementation can not guarantee
+	 *  this. This is not even guaranteed to be an array!
 	 *
+	 * @throws IllegalValueException if $data is not in the expected format. Subclasses of
+	 *  InvalidArgumentException are expected and properly handled by @see DataValueDeserializer.
 	 * @return self
-	 * @throws IllegalValueException
 	 */
-	public static function newFromArray( array $data ) {
+	public static function newFromArray( $data ) {
 		self::requireArrayFields( $data, array( 'latitude', 'longitude' ) );
 
 		return new static(

--- a/src/Values/LatLongValue.php
+++ b/src/Values/LatLongValue.php
@@ -22,8 +22,6 @@ class LatLongValue extends DataValueObject {
 	/**
 	 * The locations latitude.
 	 *
-	 * @since 0.1
-	 *
 	 * @var float
 	 */
 	protected $latitude;
@@ -31,15 +29,11 @@ class LatLongValue extends DataValueObject {
 	/**
 	 * The locations longitude.
 	 *
-	 * @since 0.1
-	 *
 	 * @var float
 	 */
 	protected $longitude;
 
 	/**
-	 * @since 0.1
-	 *
 	 * @param float|int $latitude
 	 * @param float|int $longitude
 	 *
@@ -90,8 +84,6 @@ class LatLongValue extends DataValueObject {
 	/**
 	 * @see Serializable::serialize
 	 *
-	 * @since 0.1
-	 *
 	 * @return string
 	 */
 	public function serialize() {
@@ -105,8 +97,6 @@ class LatLongValue extends DataValueObject {
 
 	/**
 	 * @see Serializable::unserialize
-	 *
-	 * @since 0.1
 	 *
 	 * @param string $value
 	 *
@@ -125,8 +115,6 @@ class LatLongValue extends DataValueObject {
 	/**
 	 * @see DataValue::getType
 	 *
-	 * @since 0.1
-	 *
 	 * @return string
 	 */
 	public static function getType() {
@@ -137,8 +125,6 @@ class LatLongValue extends DataValueObject {
 	/**
 	 * @see DataValue::getSortKey
 	 *
-	 * @since 0.1
-	 *
 	 * @return float
 	 */
 	public function getSortKey() {
@@ -148,8 +134,6 @@ class LatLongValue extends DataValueObject {
 	/**
 	 * @see DataValue::getValue
 	 *
-	 * @since 0.1
-	 *
 	 * @return self
 	 */
 	public function getValue() {
@@ -157,8 +141,6 @@ class LatLongValue extends DataValueObject {
 	}
 
 	/**
-	 * @since 0.1
-	 *
 	 * @return float
 	 */
 	public function getLatitude() {
@@ -166,8 +148,6 @@ class LatLongValue extends DataValueObject {
 	}
 
 	/**
-	 * @since 0.1
-	 *
 	 * @return float
 	 */
 	public function getLongitude() {
@@ -176,8 +156,6 @@ class LatLongValue extends DataValueObject {
 
 	/**
 	 * @see DataValue::getArrayValue
-	 *
-	 * @since 0.1
 	 *
 	 * @return float[]
 	 */
@@ -189,16 +167,24 @@ class LatLongValue extends DataValueObject {
 	}
 
 	/**
-	 * Constructs a new instance of the DataValue from the provided data.
-	 * This can round-trip with @see getArrayValue
+	 * Constructs a new instance from the provided data. Required for @see DataValueDeserializer.
+	 * This is expected to round-trip with @see getArrayValue.
 	 *
-	 * @since 0.1
+	 * @deprecated since 2.0.1. Static DataValue::newFromArray constructors like this are
+	 *  underspecified (not in the DataValue interface), and misleadingly named (should be named
+	 *  newFromArrayValue). Instead, use DataValue builder callbacks in @see DataValueDeserializer.
 	 *
-	 * @param array $data
+	 * @param mixed $data Warning! Even if this is expected to be a value as returned by
+	 *  @see getArrayValue, callers of this specific newFromArray implementation can not guarantee
+	 *  this. This is not even guaranteed to be an array!
 	 *
+	 * @throws InvalidArgumentException if $data is not in the expected format. Subclasses of
+	 *  InvalidArgumentException are expected and properly handled by @see DataValueDeserializer.
 	 * @return self
 	 */
-	public static function newFromArray( array $data ) {
+	public static function newFromArray( $data ) {
+		self::requireArrayFields( $data, [ 'latitude', 'longitude' ] );
+
 		return new static( $data['latitude'], $data['longitude'] );
 	}
 

--- a/tests/unit/Values/GlobeCoordinateValueTest.php
+++ b/tests/unit/Values/GlobeCoordinateValueTest.php
@@ -4,6 +4,7 @@ namespace Tests\DataValues\Geo\Values;
 
 use DataValues\Geo\Values\GlobeCoordinateValue;
 use DataValues\Geo\Values\LatLongValue;
+use DataValues\IllegalValueException;
 use DataValues\Tests\DataValueTest;
 
 /**
@@ -117,6 +118,24 @@ class GlobeCoordinateValueTest extends DataValueTest {
 		);
 
 		$this->assertSame( $expected, $actual );
+	}
+
+	public function provideIllegalArrayValue() {
+		return [
+			[ null ],
+			[ '' ],
+			[ [] ],
+			[ [ 'latitude' => 0 ] ],
+			[ [ 'longitude' => 0 ] ],
+		];
+	}
+
+	/**
+	 * @dataProvider provideIllegalArrayValue
+	 */
+	public function testNewFromArrayErrorHandling( $data ) {
+		$this->setExpectedException( IllegalValueException::class );
+		GlobeCoordinateValue::newFromArray( $data );
 	}
 
 	public function testArrayValueCompatibility() {


### PR DESCRIPTION
I'm aware LatLongValue::newFromArray is not tested (and was never tested before). This does not matter much because it was never used anyway, at least not on wikidata.org.

[Bug: T168681](https://phabricator.wikimedia.org/T168681)