### PR TITLE
Composition cleanup in GlobeCoordinateFormatter

### DIFF
--- a/src/Formatters/GlobeCoordinateFormatter.php
+++ b/src/Formatters/GlobeCoordinateFormatter.php
@@ -4,7 +4,8 @@ namespace DataValues\Geo\Formatters;
 
 use DataValues\Geo\Values\GlobeCoordinateValue;
 use InvalidArgumentException;
-use ValueFormatters\ValueFormatterBase;
+use ValueFormatters\FormatterOptions;
+use ValueFormatters\ValueFormatter;
 
 /**
  * Geographical coordinates formatter.
@@ -20,7 +21,16 @@ use ValueFormatters\ValueFormatterBase;
  * @license GPL-2.0+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-class GlobeCoordinateFormatter extends ValueFormatterBase {
+class GlobeCoordinateFormatter implements ValueFormatter {
+
+	/**
+	 * @var LatLongFormatter
+	 */
+	private $formatter;
+
+	public function __construct( FormatterOptions $options = null ) {
+		$this->formatter = new LatLongFormatter( $options );
+	}
 
 	/**
 	 * @see ValueFormatter::format
@@ -35,9 +45,7 @@ class GlobeCoordinateFormatter extends ValueFormatterBase {
 			throw new InvalidArgumentException( 'Data value type mismatch. Expected a GlobeCoordinateValue.' );
 		}
 
-		$formatter = new LatLongFormatter( $this->options );
-
-		return $formatter->formatLatLongValue( $value->getLatLong(), $value->getPrecision() );
+		return $this->formatter->formatLatLongValue( $value->getLatLong(), $value->getPrecision() );
 	}
 
 }


### PR DESCRIPTION
The reason to touch this class is so that it does not create a new LatLongFormatter object every single time the format method is called.

I'm not sure if this should count as a breaking change:
* The constructor is the exact same as before. No breaking change here.
* But I removed the base class (because it's features are just not used). This is a breaking change for possible GlobeCoordinateFormatter subclasses, if they call a method from the removed base class.

Personally I would not count this as a breaking change, because subclasses of GlobeCoordinateFormatter should not and [do not](https://github.com/search?type=Code&q="extends+GlobeCoordinateFormatter") exist.