### PR TITLE
Re-add test cases for non-string values

### DIFF
--- a/tests/unit/Parsers/DdCoordinateParserTest.php
+++ b/tests/unit/Parsers/DdCoordinateParserTest.php
@@ -70,18 +70,13 @@ class DdCoordinateParserTest extends ParserTestBase {
 	 * @see StringValueParserTest::invalidInputProvider
 	 */
 	public function invalidInputProvider() {
-		$argLists = [];
-
-		$invalid = [
-			'~=[,,_,,]:3',
-			'ohi there',
+		return [
+			[ null ],
+			[ 1 ],
+			[ 0.1 ],
+			[ '~=[,,_,,]:3' ],
+			[ 'ohi there' ],
 		];
-
-		foreach ( $invalid as $value ) {
-			$argLists[] = [ $value ];
-		}
-
-		return $argLists;
 	}
 
 }

--- a/tests/unit/Parsers/DmCoordinateParserTest.php
+++ b/tests/unit/Parsers/DmCoordinateParserTest.php
@@ -70,18 +70,13 @@ class DmCoordinateParserTest extends ParserTestBase {
 	 * @see StringValueParserTest::invalidInputProvider
 	 */
 	public function invalidInputProvider() {
-		$argLists = [];
-
-		$invalid = [
-			'~=[,,_,,]:3',
-			'ohi there',
+		return [
+			[ null ],
+			[ 1 ],
+			[ 0.1 ],
+			[ '~=[,,_,,]:3' ],
+			[ 'ohi there' ],
 		];
-
-		foreach ( $invalid as $value ) {
-			$argLists[] = [ $value ];
-		}
-
-		return $argLists;
 	}
 
 }

--- a/tests/unit/Parsers/DmsCoordinateParserTest.php
+++ b/tests/unit/Parsers/DmsCoordinateParserTest.php
@@ -73,18 +73,13 @@ class DmsCoordinateParserTest extends ParserTestBase {
 	 * @see StringValueParserTest::invalidInputProvider
 	 */
 	public function invalidInputProvider() {
-		$argLists = [];
-
-		$invalid = [
-			'~=[,,_,,]:3',
-			'ohi there',
+		return [
+			[ null ],
+			[ 1 ],
+			[ 0.1 ],
+			[ '~=[,,_,,]:3' ],
+			[ 'ohi there' ],
 		];
-
-		foreach ( $invalid as $value ) {
-			$argLists[] = [ $value ];
-		}
-
-		return $argLists;
 	}
 
 }

--- a/tests/unit/Parsers/FloatCoordinateParserTest.php
+++ b/tests/unit/Parsers/FloatCoordinateParserTest.php
@@ -72,18 +72,13 @@ class FloatCoordinateParserTest extends ParserTestBase {
 	 * @see StringValueParserTest::invalidInputProvider
 	 */
 	public function invalidInputProvider() {
-		$argLists = [];
-
-		$invalid = [
-			'~=[,,_,,]:3',
-			'ohi there',
+		return [
+			[ null ],
+			[ 1 ],
+			[ 0.1 ],
+			[ '~=[,,_,,]:3' ],
+			[ 'ohi there' ],
 		];
-
-		foreach ( $invalid as $value ) {
-			$argLists[] = [ $value ];
-		}
-
-		return $argLists;
 	}
 
 }

--- a/tests/unit/Parsers/GlobeCoordinateParserTest.php
+++ b/tests/unit/Parsers/GlobeCoordinateParserTest.php
@@ -122,18 +122,13 @@ class GlobeCoordinateParserTest extends ParserTestBase {
 	 * @see StringValueParserTest::invalidInputProvider
 	 */
 	public function invalidInputProvider() {
-		$argLists = [];
-
-		$invalid = [
-			'~=[,,_,,]:3',
-			'ohi there',
+		return [
+			[ null ],
+			[ 1 ],
+			[ 0.1 ],
+			[ '~=[,,_,,]:3' ],
+			[ 'ohi there' ],
 		];
-
-		foreach ( $invalid as $value ) {
-			$argLists[] = [ $value ];
-		}
-
-		return $argLists;
 	}
 
 	public function testWithGlobeOptionMatchingTheDefault() {

--- a/tests/unit/Parsers/LatLongParserTest.php
+++ b/tests/unit/Parsers/LatLongParserTest.php
@@ -105,18 +105,13 @@ class LatLongParserTest extends ParserTestBase {
 	 * @see StringValueParserTest::invalidInputProvider
 	 */
 	public function invalidInputProvider() {
-		$argLists = [];
-
-		$invalid = [
-			'~=[,,_,,]:3',
-			'ohi there',
+		return [
+			[ null ],
+			[ 1 ],
+			[ 0.1 ],
+			[ '~=[,,_,,]:3' ],
+			[ 'ohi there' ],
 		];
-
-		foreach ( $invalid as $value ) {
-			$argLists[] = [ $value ];
-		}
-
-		return $argLists;
 	}
 
 }

--- a/tests/unit/Parsers/ParserTestBase.php
+++ b/tests/unit/Parsers/ParserTestBase.php
@@ -7,25 +7,12 @@ use ValueParsers\ParseException;
 use ValueParsers\ValueParser;
 
 /**
- * @deprecated
- * TODO: remove
- * This is a copy of ValueParserTestBase from DataValues Common,
- * created so we can stop depending on that comment even though we
- * did not refactor away the inheritance abuse here yet.
+ * @deprecated This is a copy of ValueParserTestBase from DataValues Common, temporarily created to
+ * be able to refactor it away in easy to follow steps.
  *
  * @license GPL-2.0+
  */
 abstract class ParserTestBase extends \PHPUnit_Framework_TestCase {
-
-	/**
-	 * @return array[]
-	 */
-	abstract public function validInputProvider();
-
-	/**
-	 * @return array[]
-	 */
-	abstract public function invalidInputProvider();
 
 	/**
 	 * @return ValueParser
@@ -33,47 +20,31 @@ abstract class ParserTestBase extends \PHPUnit_Framework_TestCase {
 	abstract protected function getInstance();
 
 	/**
-	 * @dataProvider validInputProvider
-	 * @param mixed $value
-	 * @param mixed $expected
-	 * @param ValueParser|null $parser
+	 * @return array[]
 	 */
-	public function testParseWithValidInputs( $value, $expected, ValueParser $parser = null ) {
-		if ( $parser === null ) {
-			$parser = $this->getInstance();
-		}
-
-		$this->assertSmartEquals( $expected, $parser->parse( $value ) );
-	}
+	abstract public function validInputProvider();
 
 	/**
-	 * @param DataValue|mixed $expected
-	 * @param DataValue|mixed $actual
+	 * @dataProvider validInputProvider
 	 */
-	private function assertSmartEquals( $expected, $actual ) {
-		if ( $expected instanceof DataValue && $actual instanceof DataValue ) {
-			$msg = "testing equals():\n"
-				. preg_replace( '/\s+/', ' ', print_r( $actual->toArray(), true ) ) . " should equal\n"
-				. preg_replace( '/\s+/', ' ', print_r( $expected->toArray(), true ) );
-		} else {
-			$msg = 'testing equals()';
-		}
-
+	public function testParseWithValidInputs( $value, DataValue $expected ) {
+		$actual = $this->getInstance()->parse( $value );
+		$msg = json_encode( $actual->toArray() ) . " should equal\n"
+			. json_encode( $expected->toArray() );
 		$this->assertTrue( $expected->equals( $actual ), $msg );
 	}
 
 	/**
-	 * @dataProvider invalidInputProvider
-	 * @param mixed $value
-	 * @param ValueParser|null $parser
+	 * @return array[]
 	 */
-	public function testParseWithInvalidInputs( $value, ValueParser $parser = null ) {
-		if ( $parser === null ) {
-			$parser = $this->getInstance();
-		}
+	abstract public function invalidInputProvider();
 
+	/**
+	 * @dataProvider invalidInputProvider
+	 */
+	public function testParseWithInvalidInputs( $value ) {
 		$this->setExpectedException( ParseException::class );
-		$parser->parse( $value );
+		$this->getInstance()->parse( $value );
 	}
 
 }


### PR DESCRIPTION
I did not merged #123 for one reason: the test cases did not covered calling the constructor with non-strings any more. This patch fixes this. Note it sits on top of #123 and should be merged first.

This also removes a surprising amount of unused code from the already deprecated ParserTestBase. I also replaced the preg_replace with json_encode for the sake of simplicity.