### PR TITLE
 Fix parsing of DMS coordinate with one minute missing 

### DIFF
--- a/src/Parsers/DmsCoordinateParser.php
+++ b/src/Parsers/DmsCoordinateParser.php
@@ -143,14 +143,14 @@ class DmsCoordinateParser extends DmCoordinateParser {
 	 * @return float
 	 */
 	protected function parseCoordinate( string $coordinateSegment ): float {
-		$isNegative = substr( $coordinateSegment, 0, 1 ) === '-';
+		$isNegative = mb_substr( $coordinateSegment, 0, 1 ) === '-';
 
 		if ( $isNegative ) {
-			$coordinateSegment = substr( $coordinateSegment, 1 );
+			$coordinateSegment = mb_substr( $coordinateSegment, 1 );
 		}
 
 		$degreeSymbol = $this->getOption( self::OPT_DEGREE_SYMBOL );
-		$degreePosition = strpos( $coordinateSegment, $degreeSymbol );
+		$degreePosition = mb_strpos( $coordinateSegment, $degreeSymbol );
 
 		if ( $degreePosition === false ) {
 			throw new ParseException(
@@ -160,25 +160,28 @@ class DmsCoordinateParser extends DmCoordinateParser {
 			);
 		}
 
-		$degrees = (float)substr( $coordinateSegment, 0, $degreePosition );
+		$degrees = (float)mb_substr( $coordinateSegment, 0, $degreePosition );
 
-		$minutePosition = strpos( $coordinateSegment, $this->getOption( self::OPT_MINUTE_SYMBOL ) );
+		$minutePosition = mb_strpos( $coordinateSegment, $this->getOption( self::OPT_MINUTE_SYMBOL ) );
 
 		if ( $minutePosition === false ) {
 			$minutes = 0;
 		} else {
-			$degSignLength = strlen( $this->getOption( self::OPT_DEGREE_SYMBOL ) );
+			$degSignLength = mb_strlen( $this->getOption( self::OPT_DEGREE_SYMBOL ) );
 			$minuteLength = $minutePosition - $degreePosition - $degSignLength;
-			$minutes = substr( $coordinateSegment, $degreePosition + $degSignLength, $minuteLength );
+			$minutes = (float)mb_substr( $coordinateSegment, $degreePosition + $degSignLength, $minuteLength );
 		}
 
-		$secondPosition = strpos( $coordinateSegment, $this->getOption( self::OPT_SECOND_SYMBOL ) );
+		$secondPosition = mb_strpos( $coordinateSegment, $this->getOption( self::OPT_SECOND_SYMBOL ) );
 
 		if ( $secondPosition === false ) {
 			$seconds = 0;
 		} else {
-			$secondLength = $secondPosition - $minutePosition - 1;
-			$seconds = substr( $coordinateSegment, $minutePosition + 1, $secondLength );
+			$seconds = (float)mb_substr(
+				$coordinateSegment,
+				( $minutePosition === false ? $degreePosition : $minutePosition ) + 1,
+				-1
+			);
 		}
 
 		$coordinateSegment = $degrees + ( $minutes + $seconds / 60 ) / 60;

--- a/tests/unit/Parsers/DmsCoordinateParserTest.php
+++ b/tests/unit/Parsers/DmsCoordinateParserTest.php
@@ -81,4 +81,15 @@ class DmsCoordinateParserTest extends TestCase {
 		yield [ 'ohi there' ];
 	}
 
+	public function testWhenSingleMinutePositionIsMissing_itGetsDefaultedToZero() {
+		$this->assertEquals(
+			new LatLongValue( 1.0005555555555556, 4.085 ),
+			$this->parse( '1°2"N, 4°5\'6"E' )
+		);
+	}
+
+	private function parse( string $input ): LatLongValue {
+		return ( new DmsCoordinateParser() )->parse( $input );
+	}
+
 }

--- a/tests/unit/Parsers/DmsCoordinateParserTest.php
+++ b/tests/unit/Parsers/DmsCoordinateParserTest.php
@@ -4,6 +4,8 @@ namespace Tests\DataValues\Geo\Parsers;
 
 use DataValues\Geo\Parsers\DmsCoordinateParser;
 use DataValues\Geo\Values\LatLongValue;
+use PHPUnit\Framework\TestCase;
+use ValueParsers\ParseException;
 
 /**
  * @covers \DataValues\Geo\Parsers\DmsCoordinateParser
@@ -14,72 +16,69 @@ use DataValues\Geo\Values\LatLongValue;
  * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-class DmsCoordinateParserTest extends ParserTestBase {
+class DmsCoordinateParserTest extends TestCase {
 
 	/**
-	 * @see ValueParserTestBase::getInstance
-	 *
-	 * @return DmsCoordinateParser
+	 * @dataProvider validInputProvider
 	 */
-	protected function getInstance() {
-		return new DmsCoordinateParser();
+	public function testParseWithValidInputs( $value, LatLongValue $expected ) {
+		$this->assertEquals(
+			$expected,
+			( new DmsCoordinateParser() )->parse( $value )
+		);
 	}
 
 	/**
 	 * @see ValueParserTestBase::validInputProvider
 	 */
 	public function validInputProvider() {
-		$argLists = [];
-
-		// TODO: test with different parser options
-
 		$valid = [
 			// Whitespace
-			"1°0'0\"N 1°0'0\"E\n" => [ 1, 1 ],
-			' 1°0\'0"N 1°0\'0"E ' => [ 1, 1 ],
+			"1°0'0\"N 1°0'0\"E\n" => new LatLongValue( 1, 1 ),
+			' 1°0\'0"N 1°0\'0"E ' => new LatLongValue( 1, 1 ),
 
-			'55° 45\' 20.8296", 37° 37\' 3.4788"' => [ 55.755786, 37.617633 ],
-			'55° 45\' 20.8296", -37° 37\' 3.4788"' => [ 55.755786, -37.617633 ],
-			'-55° 45\' 20.8296", -37° 37\' 3.4788"' => [ -55.755786, -37.617633 ],
-			'-55° 45\' 20.8296", 37° 37\' 3.4788"' => [ -55.755786, 37.617633 ],
-			'55° 0\' 0", 37° 0\' 0"' => [ 55, 37 ],
-			'55° 30\' 0", 37° 30\' 0"' => [ 55.5, 37.5 ],
-			'55° 0\' 18", 37° 0\' 18"' => [ 55.005, 37.005 ],
-			'0° 0\' 0", 0° 0\' 0"' => [ 0, 0 ],
-			'0° 0\' 18" N, 0° 0\' 18" E' => [ 0.005, 0.005 ],
-			' 0° 0\' 18" S  , 0°  0\' 18"  W ' => [ -0.005, -0.005 ],
-			'55° 0′ 18″, 37° 0′ 18″' => [ 55.005, 37.005 ],
+			'55° 45\' 20.8296", 37° 37\' 3.4788"' => new LatLongValue( 55.755786, 37.617633 ),
+			'55° 45\' 20.8296", -37° 37\' 3.4788"' => new LatLongValue( 55.755786, -37.617633 ),
+			'-55° 45\' 20.8296", -37° 37\' 3.4788"' => new LatLongValue( -55.755786, -37.617633 ),
+			'-55° 45\' 20.8296", 37° 37\' 3.4788"' => new LatLongValue( -55.755786, 37.617633 ),
+			'55° 0\' 0", 37° 0\' 0"' => new LatLongValue( 55, 37 ),
+			'55° 30\' 0", 37° 30\' 0"' => new LatLongValue( 55.5, 37.5 ),
+			'55° 0\' 18", 37° 0\' 18"' => new LatLongValue( 55.005, 37.005 ),
+			'0° 0\' 0", 0° 0\' 0"' => new LatLongValue( 0, 0 ),
+			'0° 0\' 18" N, 0° 0\' 18" E' => new LatLongValue( 0.005, 0.005 ),
+			' 0° 0\' 18" S  , 0°  0\' 18"  W ' => new LatLongValue( -0.005, -0.005 ),
+			'55° 0′ 18″, 37° 0′ 18″' => new LatLongValue( 55.005, 37.005 ),
 
 			// Coordinate strings without separator:
-			'55° 45\' 20.8296" 37° 37\' 3.4788"' => [ 55.755786, 37.617633 ],
-			'55 ° 45 \' 20.8296 " -37 ° 37 \' 3.4788 "' => [ 55.755786, -37.617633 ],
-			'-55 ° 45 \' 20.8296 " -37° 37\' 3.4788"' => [ -55.755786, -37.617633 ],
-			'55° 0′ 18″ 37° 0′ 18″' => [ 55.005, 37.005 ],
+			'55° 45\' 20.8296" 37° 37\' 3.4788"' => new LatLongValue( 55.755786, 37.617633 ),
+			'55 ° 45 \' 20.8296 " -37 ° 37 \' 3.4788 "' => new LatLongValue( 55.755786, -37.617633 ),
+			'-55 ° 45 \' 20.8296 " -37° 37\' 3.4788"' => new LatLongValue( -55.755786, -37.617633 ),
+			'55° 0′ 18″ 37° 0′ 18″' => new LatLongValue( 55.005, 37.005 ),
 
 			// Coordinate string starting with direction character:
-			'N 0° 0\' 18", E 0° 0\' 18"' => [ 0.005, 0.005 ],
-			'S 0° 0\' 18" E 0° 0\' 18"' => [ -0.005, 0.005 ],
+			'N 0° 0\' 18", E 0° 0\' 18"' => new LatLongValue( 0.005, 0.005 ),
+			'S 0° 0\' 18" E 0° 0\' 18"' => new LatLongValue( -0.005, 0.005 ),
 		];
 
-		foreach ( $valid as $value => $expected ) {
-			$expected = new LatLongValue( $expected[0], $expected[1] );
-			$argLists[] = [ (string)$value, $expected ];
+		foreach ( $valid as $input => $expected ) {
+			yield [ $input, $expected ];
 		}
-
-		return $argLists;
 	}
 
 	/**
-	 * @see StringValueParserTest::invalidInputProvider
+	 * @dataProvider invalidInputProvider
 	 */
+	public function testParseWithInvalidInputs( $value ) {
+		$this->expectException( ParseException::class );
+		( new DmsCoordinateParser() )->parse( $value );
+	}
+
 	public function invalidInputProvider() {
-		return [
-			[ null ],
-			[ 1 ],
-			[ 0.1 ],
-			[ '~=[,,_,,]:3' ],
-			[ 'ohi there' ],
-		];
+		yield [ null ];
+		yield [ 1 ];
+		yield [ 0.1 ];
+		yield [ '~=[,,_,,]:3' ];
+		yield [ 'ohi there' ];
 	}
 
 }


### PR DESCRIPTION
Includes casting of strings to floats (caused problems with strict mode on new PHP)
and using of multibyte string functions (which did not cause problems since PHP is kind).