### PR TITLE
Undeprecate LatLongValue::newFromArray

### DIFF
--- a/src/Values/LatLongValue.php
+++ b/src/Values/LatLongValue.php
@@ -114,9 +114,6 @@ class LatLongValue implements DataValue {
 	/**
 	 * Constructs a new instance from the provided array. Round-trips with @see getArrayValue.
 	 *
-	 * @deprecated since 2.0.1. When using this static constructor for DataValues of unknown
-	 * types, please use DataValueDeserializer from the data-values/serialization package instead.
-	 *
 	 * @throws InvalidArgumentException
 	 */
 	public static function newFromArray( $data ): self {


### PR DESCRIPTION
While DataValue::newFromArray is problematic, LatLongValue::newFromArray on itself is fine