### PR TITLE
Reset the iterator in LatLongPrecisionParser when one of them error out

### DIFF
--- a/src/PackagePrivate/LatLongPrecisionParser.php
+++ b/src/PackagePrivate/LatLongPrecisionParser.php
@@ -23,6 +23,7 @@ class LatLongPrecisionParser {
 			try {
 				$latLongPrecision = $parser->parse( $coordinate );
 			} catch ( ParseException $parseException ) {
+				$this->parsers = null;
 				continue;
 			}
 


### PR DESCRIPTION
This avoids errors like "Cannot rewind a generator that was already run"
When the first parser has invalid value but everything after it is okay

Caught with an integration test in ParserValue API module in Wikibase

Bug: https://phabricator.wikimedia.org/T238931