### PR TITLE
Allow numeric String values in newFromArray

### DIFF
--- a/src/Values/GlobeCoordinateValue.php
+++ b/src/Values/GlobeCoordinateValue.php
@@ -208,18 +208,18 @@ class GlobeCoordinateValue implements DataValue {
 			throw new IllegalValueException( 'array expected' );
 		}
 
-		if ( !array_key_exists( 'latitude', $data ) ) {
-			throw new IllegalValueException( 'latitude field required' );
+		if ( !array_key_exists( 'latitude', $data ) || !is_numeric( $data['latitude'] ) ) {
+			throw new IllegalValueException( 'numeric latitude field required' );
 		}
 
-		if ( !array_key_exists( 'longitude', $data ) ) {
-			throw new IllegalValueException( 'longitude field required' );
+		if ( !array_key_exists( 'longitude', $data ) || !is_numeric( $data['longitude'] ) ) {
+			throw new IllegalValueException( 'numeric longitude field required' );
 		}
 
 		return new self(
 			new LatLongValue(
-				$data['latitude'],
-				$data['longitude']
+				(float)$data['latitude'],
+				(float)$data['longitude']
 			),
 			( isset( $data['precision'] ) ) ? $data['precision'] : null,
 			( isset( $data['globe'] ) ) ? $data['globe'] : null

--- a/tests/unit/Values/GlobeCoordinateValueTest.php
+++ b/tests/unit/Values/GlobeCoordinateValueTest.php
@@ -280,6 +280,29 @@ class GlobeCoordinateValueTest extends TestCase {
 		GlobeCoordinateValue::newFromArray( 'such' );
 	}
 
+	public function testNewFromArrayWithNumericStringValues() {
+		$globeCoordinate = GlobeCoordinateValue::newFromArray( [ 'latitude' => '12.3', 'longitude' => '45.6' ] );
+
+		$this->assertSame( 12.3, $globeCoordinate->getLatitude() );
+		$this->assertSame( 45.6, $globeCoordinate->getLongitude() );
+	}
+
+	/**
+	 * @dataProvider nonNumericStringProvider
+	 */
+	public function testNewFromArrayWithNonNumericStringValuesCausesException( array $nonNumericStringValues ) {
+		$this->expectException( \InvalidArgumentException::class );
+		GlobeCoordinateValue::newFromArray( $nonNumericStringValues );
+	}
+
+	public function nonNumericStringProvider() {
+		yield [ [ 'latitude' => 'foo', 'longitude' => '4.56' ] ];
+		yield [ [ 'latitude' => '12.3', 'longitude' => 'bar' ] ];
+		yield [ [ 'latitude' => 'foo', 'longitude' => 'bar' ] ];
+		yield [ [ 'latitude' => '1.23a', 'longitude' => '3.45b' ] ];
+	}
+
+
 	/**
 	 * @dataProvider withPrecisionProvider
 	 */


### PR DESCRIPTION
This fixes https://phabricator.wikimedia.org/T277691.
When sending API requests with String lat/long values, a cast to float is needed in order to avoid a TypeError.

Bug: T277691