### PR TITLE
Implement __serialize()/__unserialize()

### DIFF
--- a/src/Values/GlobeCoordinateValue.php
+++ b/src/Values/GlobeCoordinateValue.php
@@ -128,7 +128,11 @@ class GlobeCoordinateValue implements DataValue {
 	 * @return string
 	 */
 	public function serialize(): string {
-		return json_encode( array_values( $this->getArrayValue() ) );
+		return json_encode( $this->__serialize() );
+	}
+
+	public function __serialize(): array {
+		return array_values( $this->getArrayValue() );
 	}
 
 	/**
@@ -139,7 +143,11 @@ class GlobeCoordinateValue implements DataValue {
 	 * @throws InvalidArgumentException
 	 */
 	public function unserialize( $value ) {
-		[ $latitude, $longitude, $altitude, $precision, $globe ] = json_decode( $value );
+		$this->__unserialize( json_decode( $value) );
+	}
+
+	public function __unserialize( array $data ): void {
+		[ $latitude, $longitude, $altitude, $precision, $globe ] = $data;
 		$this->__construct( new LatLongValue( $latitude, $longitude ), $precision, $globe );
 	}
 

--- a/tests/unit/PackagePrivate/DmPrecisionDetectorTest.php
+++ b/tests/unit/PackagePrivate/DmPrecisionDetectorTest.php
@@ -20,9 +20,10 @@ class DmPrecisionDetectorTest extends TestCase {
 	public function testPrecisionDetection( string $coordinate, float $expectedPrecision ) {
 		$latLong = ( new DmCoordinateParser() )->parse( $coordinate );
 
-		$this->assertSame(
+		$this->assertEqualsWithDelta(
 			$expectedPrecision,
-			( new DmPrecisionDetector() )->detectPrecision( $latLong )->toFloat()
+			( new DmPrecisionDetector() )->detectPrecision( $latLong )->toFloat(),
+			PHP_FLOAT_EPSILON
 		);
 	}
 

--- a/tests/unit/PackagePrivate/DmsPrecisionDetectorTest.php
+++ b/tests/unit/PackagePrivate/DmsPrecisionDetectorTest.php
@@ -20,9 +20,10 @@ class DmsPrecisionDetectorTest extends TestCase {
 	public function testPrecisionDetection( string $coordinate, float $expectedPrecision ) {
 		$latLong = ( new DmsCoordinateParser() )->parse( $coordinate );
 
-		$this->assertSame(
+		$this->assertEqualsWithDelta(
 			$expectedPrecision,
-			( new DmsPrecisionDetector() )->detectPrecision( $latLong )->toFloat()
+			( new DmsPrecisionDetector() )->detectPrecision( $latLong )->toFloat(),
+			PHP_FLOAT_EPSILON
 		);
 	}
 

--- a/tests/unit/Parsers/GlobeCoordinateParserTest.php
+++ b/tests/unit/Parsers/GlobeCoordinateParserTest.php
@@ -189,7 +189,11 @@ class GlobeCoordinateParserTest extends TestCase {
 		$parser = new GlobeCoordinateParser();
 		$globeCoordinateValue = $parser->parse( $value );
 
-		$this->assertSame( (float)$expected, $globeCoordinateValue->getPrecision() );
+		$this->assertEqualsWithDelta(
+			(float)$expected,
+			$globeCoordinateValue->getPrecision(),
+			PHP_FLOAT_EPSILON
+		);
 	}
 
 	public function precisionDetectionProvider() {


### PR DESCRIPTION
In this case, I think it makes more sense to implement the old methods serialize() and unserialize() in terms of the new methods, rather than the other way around, since the old methods were already array-based.

Also add getSerializationForHash() to LatLongValue to keep the hash stable; it’s directly copied from DataValueObject. (I assume the DataValue classes in this package don’t extend DataValueObject because it still claims compatibility with ancient data-values versions.)

Bug: T301249