### PR TITLE
Generate MismatchingOptionTypeException if bad options are supplied

### DIFF
--- a/src/Formatters/LatLongFormatter.php
+++ b/src/Formatters/LatLongFormatter.php
@@ -7,6 +7,7 @@ namespace DataValues\Geo\Formatters;
 use DataValues\Geo\Values\LatLongValue;
 use InvalidArgumentException;
 use ValueFormatters\FormatterOptions;
+use ValueFormatters\MismatchingOptionTypeException;
 use ValueFormatters\ValueFormatter;
 
 /**
@@ -170,15 +171,14 @@ class LatLongFormatter implements ValueFormatter {
 			$precision = self::DEFAULT_PRECISION;
 		}
 
-		$formatted = implode(
-			$this->options->getOption( self::OPT_SEPARATOR_SYMBOL ) . $this->getSpacing( self::OPT_SPACE_LATLONG ),
+		return implode(
+			$this->options->getStringOption( self::OPT_SEPARATOR_SYMBOL ) .
+				$this->getSpacing( self::OPT_SPACE_LATLONG ),
 			[
 				$this->formatLatitude( $value->getLatitude(), $precision ),
 				$this->formatLongitude( $value->getLongitude(), $precision )
 			]
 		);
-
-		return $formatted;
 	}
 
 	/**
@@ -187,7 +187,16 @@ class LatLongFormatter implements ValueFormatter {
 	 * @return string
 	 */
 	private function getSpacing( string $spacingLevel ): string {
-		if ( in_array( $spacingLevel, $this->options->getOption( self::OPT_SPACING_LEVEL ) ) ) {
+		$levels = $this->options->getOption( self::OPT_SPACING_LEVEL );
+		if ( is_array( $levels ) === false ) {
+			throw new MismatchingOptionTypeException(
+				"array",
+				getType( $levels ),
+				"Invalid option supplied for " .
+					self::OPT_SPACING_LEVEL . " - expected array, got " . getType( $levels )
+			);
+		}
+		if ( in_array( $spacingLevel, $levels ) ) {
 			return ' ';
 		}
 		return '';
@@ -196,16 +205,16 @@ class LatLongFormatter implements ValueFormatter {
 	private function formatLatitude( float $latitude, float $precision ): string {
 		return $this->makeDirectionalIfNeeded(
 			$this->formatCoordinate( $latitude, $precision ),
-			$this->options->getOption( self::OPT_NORTH_SYMBOL ),
-			$this->options->getOption( self::OPT_SOUTH_SYMBOL )
+			$this->options->getStringOption( self::OPT_NORTH_SYMBOL ),
+			$this->options->getStringOption( self::OPT_SOUTH_SYMBOL )
 		);
 	}
 
 	private function formatLongitude( float $longitude, float $precision ): string {
 		return $this->makeDirectionalIfNeeded(
 			$this->formatCoordinate( $longitude, $precision ),
-			$this->options->getOption( self::OPT_EAST_SYMBOL ),
-			$this->options->getOption( self::OPT_WEST_SYMBOL )
+			$this->options->getStringOption( self::OPT_EAST_SYMBOL ),
+			$this->options->getStringOption( self::OPT_WEST_SYMBOL )
 		);
 	}
 
@@ -293,7 +302,7 @@ class LatLongFormatter implements ValueFormatter {
 		$degreeDigits = $this->getSignificantDigits( 1, $precision );
 		$stringDegrees = $this->formatNumber( $floatDegrees, $degreeDigits );
 
-		return $stringDegrees . $this->options->getOption( self::OPT_DEGREE_SYMBOL );
+		return $stringDegrees . $this->options->getStringOption( self::OPT_DEGREE_SYMBOL );
 	}
 
 	private function getInDegreeMinuteSecondFormat( float $floatDegrees, float $precision ): string {
@@ -309,13 +318,13 @@ class LatLongFormatter implements ValueFormatter {
 
 		$space = $this->getSpacing( self::OPT_SPACE_COORDPARTS );
 		$result = $this->formatNumber( $degrees )
-			. $this->options->getOption( self::OPT_DEGREE_SYMBOL )
+			. $this->options->getStringOption( self::OPT_DEGREE_SYMBOL )
 			. $space
 			. $this->formatNumber( $minutes )
-			. $this->options->getOption( self::OPT_MINUTE_SYMBOL )
+			. $this->options->getStringOption( self::OPT_MINUTE_SYMBOL )
 			. $space
 			. $this->formatNumber( $seconds, $secondDigits )
-			. $this->options->getOption( self::OPT_SECOND_SYMBOL );
+			. $this->options->getStringOption( self::OPT_SECOND_SYMBOL );
 
 		if ( $isNegative && ( $degrees + $minutes + $seconds ) > 0 ) {
 			$result = '-' . $result;
@@ -335,10 +344,10 @@ class LatLongFormatter implements ValueFormatter {
 
 		$space = $this->getSpacing( self::OPT_SPACE_COORDPARTS );
 		$result = $this->formatNumber( $degrees )
-			. $this->options->getOption( self::OPT_DEGREE_SYMBOL )
+			. $this->options->getStringOption( self::OPT_DEGREE_SYMBOL )
 			. $space
 			. $this->formatNumber( $minutes, $minuteDigits )
-			. $this->options->getOption( self::OPT_MINUTE_SYMBOL );
+			. $this->options->getStringOption( self::OPT_MINUTE_SYMBOL );
 
 		if ( $isNegative && ( $degrees + $minutes ) > 0 ) {
 			$result = '-' . $result;

--- a/tests/unit/Formatters/GlobeCoordinateFormatterTest.php
+++ b/tests/unit/Formatters/GlobeCoordinateFormatterTest.php
@@ -11,6 +11,8 @@ use DataValues\Geo\Values\GlobeCoordinateValue;
 use DataValues\Geo\Values\LatLongValue;
 use PHPUnit\Framework\TestCase;
 use ValueFormatters\FormatterOptions;
+use ValueFormatters\MismatchingOptionTypeException;
+use ValueFormatters\ValueFormatter;
 use ValueParsers\ParserOptions;
 
 /**
@@ -108,6 +110,15 @@ class GlobeCoordinateFormatterTest extends TestCase {
 
 		$formatted = $formatter->format( new GlobeCoordinateValue( new LatLongValue( 1.2, 3.4 ), null ) );
 		$this->assertSame( '1.2, 3.4', $formatted );
+	}
+
+	public function testInvalidOptions() {
+		$options = new FormatterOptions();
+		$options->setOption( LatLongFormatter::OPT_NORTH_SYMBOL, 1 );
+		$options->setOption( LatLongFormatter::OPT_DIRECTIONAL, true );
+		$formatter = new GlobeCoordinateFormatter( $options );
+		$this->expectException( MismatchingOptionTypeException::class );
+		$formatter->format( new GlobeCoordinateValue( new LatLongValue( 1.2, 3.4 ), null ) );
 	}
 
 	/**

--- a/tests/unit/Formatters/LatLongFormatterTest.php
+++ b/tests/unit/Formatters/LatLongFormatterTest.php
@@ -11,6 +11,7 @@ use DataValues\StringValue;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use ValueFormatters\FormatterOptions;
+use ValueFormatters\MismatchingOptionTypeException;
 
 /**
  * @covers \DataValues\Geo\Formatters\LatLongFormatter
@@ -723,4 +724,69 @@ class LatLongFormatterTest extends TestCase {
 		] ) ) );
 	}
 
+	public function testProvidingInvalidLatitudeFormattingOptionThrowsMismatchException() {
+		$formatter = new LatLongFormatter( new FormatterOptions( [
+			LatLongFormatter::OPT_NORTH_SYMBOL => 1,
+			LatLongFormatter::OPT_SOUTH_SYMBOL => 2
+		] ) );
+		$this->expectException( MismatchingOptionTypeException::class );
+		$formatter->format( new LatLongValue( 1.2, 3.4 ) );
+	}
+
+	public function testProvidingInvalidLongitudeFormattingOptionThrowsMismatchException() {
+		$formatter = new LatLongFormatter( new FormatterOptions( [
+			LatLongFormatter::OPT_WEST_SYMBOL => 1,
+			LatLongFormatter::OPT_EAST_SYMBOL => 2
+		] ) );
+		$this->expectException( MismatchingOptionTypeException::class );
+		$formatter->format( new LatLongValue( 1.2, 3.4 ) );
+	}
+
+	public function testProvidingInvalidSeparatorFormattingOptionThrowsMismatchException() {
+		$formatter = new LatLongFormatter( new FormatterOptions( [
+			LatLongFormatter::OPT_SEPARATOR_SYMBOL => (object)[]
+		] ) );
+		$this->expectException( MismatchingOptionTypeException::class );
+		$formatter->format( new LatLongValue( 1.2, 3.4 ) );
+	}
+
+	public function testProvidingInvalidDegreeSymbolFormattingOptionThrowsMismatchException() {
+		$formatter = new LatLongFormatter( new FormatterOptions( [
+			LatLongFormatter::OPT_DEGREE_SYMBOL => (object)[],
+			LatLongFormatter::OPT_FORMAT => LatLongFormatter::TYPE_DD
+		] ) );
+		$this->expectException( MismatchingOptionTypeException::class );
+		$formatter->format( new LatLongValue( 1.2, 3.4 ) );
+	}
+
+	public function testProvidingInvalidDMSFormattingOptionThrowsMismatchException() {
+		$formatter = new LatLongFormatter( new FormatterOptions( [
+			LatLongFormatter::OPT_DEGREE_SYMBOL => (object)[],
+			LatLongFormatter::OPT_SECOND_SYMBOL => (object)[],
+			LatLongFormatter::OPT_MINUTE_SYMBOL => (object)[],
+			LatLongFormatter::OPT_FORMAT => LatLongFormatter::TYPE_DMS
+		] ) );
+		$this->expectException( MismatchingOptionTypeException::class );
+		$formatter->format( new LatLongValue( 1.2, 3.4 ) );
+	}
+
+	public function testProvidingInvalidDMFormattingOptionThrowsMismatchException() {
+		$formatter = new LatLongFormatter( new FormatterOptions( [
+			LatLongFormatter::OPT_DEGREE_SYMBOL => (object)[],
+			LatLongFormatter::OPT_SECOND_SYMBOL => (object)[],
+			LatLongFormatter::OPT_MINUTE_SYMBOL => (object)[],
+			LatLongFormatter::OPT_FORMAT => LatLongFormatter::TYPE_DM
+		] ) );
+		$this->expectException( MismatchingOptionTypeException::class );
+		$formatter->format( new LatLongValue( 1.2, 3.4 ) );
+	}
+
+	public function testProvidingInvalidSpacingLevelsOptionThrowsMismatchException() {
+		$formatter = new LatLongFormatter( new FormatterOptions( [
+			LatLongFormatter::OPT_SPACING_LEVEL => "3",
+			LatLongFormatter::OPT_FORMAT => LatLongFormatter::TYPE_DM
+		] ) );
+		$this->expectException( MismatchingOptionTypeException::class );
+		$formatter->format( new LatLongValue( 1.2, 3.4 ) );
+	}
 }


### PR DESCRIPTION
Avoid throwing raw TypeErrors from formatting code. Use the MismatchingOptionTypeException from data-values/interfaces to generate friendlier error messages that can be caught / processed by consumers.

This PR depends on [DataValues/Interfaces@61](https://github.com/DataValues/Interfaces/pull/61) - if this approach is acceptable we would need to bump the version of the DataValues/Interfaces dependency.

Bug: [T323778](https://phabricator.wikimedia.org/T323778)