### PR TITLE
Upgrade mediawiki-codesniffer to latest version (45.0.0)

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,7 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         php:
-          - '7.3'
           - '7.4'
           - '8.0'
           - '8.1'

--- a/composer.json
+++ b/composer.json
@@ -38,14 +38,14 @@
 		"docs": "https://github.com/DataValues/Geo/#usage"
 	},
 	"require": {
-		"php": ">=7.3",
+		"php": ">=7.4",
 		"data-values/data-values": "^3.0|^2.0|^1.0|~0.1",
 		"data-values/interfaces": "^1.0.0|^0.2.0",
 		"symfony/polyfill-php80": "^1.18.1"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^9.4.1",
-		"mediawiki/mediawiki-codesniffer": "^34 || ^35 || ^36 || ^38",
+		"mediawiki/mediawiki-codesniffer": "^45",
 		"ockcyp/covers-validator": "^1.3.3",
 		"phpstan/phpstan": "^0.12.68 || ^1.0.0",
 		"phpmd/phpmd": "^2.9.1",
@@ -83,5 +83,10 @@
 			"@test",
 			"@cs"
 		]
+	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
 	}
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -12,4 +12,5 @@
 	<rule ref="Generic.Metrics.CyclomaticComplexity" />
 	<rule ref="Generic.Metrics.NestingLevel" />
 	<rule ref="Squiz.Operators.ValidLogicalOperators" />
+	<rule ref="./vendor/mediawiki/mediawiki-codesniffer/MediaWiki"/>
 </ruleset>

--- a/src/Formatters/GlobeCoordinateFormatter.php
+++ b/src/Formatters/GlobeCoordinateFormatter.php
@@ -30,7 +30,7 @@ class GlobeCoordinateFormatter implements ValueFormatter {
 	 */
 	private $formatter;
 
-	public function __construct( FormatterOptions $options = null ) {
+	public function __construct( ?FormatterOptions $options = null ) {
 		$this->formatter = new LatLongFormatter( $options );
 	}
 

--- a/src/Formatters/LatLongFormatter.php
+++ b/src/Formatters/LatLongFormatter.php
@@ -93,9 +93,9 @@ class LatLongFormatter implements ValueFormatter {
 
 	private const DEFAULT_PRECISION = 1 / 3600;
 
-	private $options;
+	private FormatterOptions $options;
 
-	public function __construct( FormatterOptions $options = null ) {
+	public function __construct( ?FormatterOptions $options = null ) {
 		$this->options = $options ?? new FormatterOptions();
 
 		$this->defaultOption( self::OPT_NORTH_SYMBOL, 'N' );
@@ -211,7 +211,6 @@ class LatLongFormatter implements ValueFormatter {
 
 	private function makeDirectionalIfNeeded( string $coordinate, string $positiveSymbol,
 		string $negativeSymbol ): string {
-
 		if ( $this->options->getOption( self::OPT_DIRECTIONAL ) ) {
 			return $this->makeDirectional( $coordinate, $positiveSymbol, $negativeSymbol );
 		}
@@ -221,7 +220,6 @@ class LatLongFormatter implements ValueFormatter {
 
 	private function makeDirectional( string $coordinate, string $positiveSymbol,
 		string $negativeSymbol ): string {
-
 		$isNegative = substr( $coordinate, 0, 1 ) === '-';
 
 		if ( $isNegative ) {

--- a/src/GlobeMath.php
+++ b/src/GlobeMath.php
@@ -59,7 +59,7 @@ class GlobeMath {
 	 *
 	 * @return LatLongValue
 	 */
-	public function normalizeGlobeLatLong( LatLongValue $value, string $globe = null ): LatLongValue {
+	public function normalizeGlobeLatLong( LatLongValue $value, ?string $globe = null ): LatLongValue {
 		switch ( $this->normalizeGlobe( $globe ) ) {
 			case GlobeCoordinateValue::GLOBE_EARTH:
 			case self::GLOBE_MOON:

--- a/src/PackagePrivate/DmPrecisionDetector.php
+++ b/src/PackagePrivate/DmPrecisionDetector.php
@@ -6,7 +6,7 @@ namespace DataValues\Geo\PackagePrivate;
 
 class DmPrecisionDetector extends PrecisionDetector {
 
-	private $dmsPrecisionDetector;
+	private DmsPrecisionDetector $dmsPrecisionDetector;
 
 	public function __construct() {
 		$this->dmsPrecisionDetector = new DmsPrecisionDetector();

--- a/src/PackagePrivate/LatLongPrecisionParser.php
+++ b/src/PackagePrivate/LatLongPrecisionParser.php
@@ -11,10 +11,10 @@ use ValueParsers\ParserOptions;
 
 class LatLongPrecisionParser {
 
-	private $options;
-	private $parsers;
+	private ?ParserOptions $options;
+	private ?array $parsers = null;
 
-	public function __construct( ParserOptions $options = null ) {
+	public function __construct( ?ParserOptions $options = null ) {
 		$this->options = $options;
 	}
 

--- a/src/PackagePrivate/PreciseLatLong.php
+++ b/src/PackagePrivate/PreciseLatLong.php
@@ -8,8 +8,8 @@ use DataValues\Geo\Values\LatLongValue;
 
 class PreciseLatLong {
 
-	private $latLong;
-	private $precision;
+	private LatLongValue $latLong;
+	private Precision $precision;
 
 	public function __construct( LatLongValue $latLong, Precision $precision ) {
 		$this->latLong = $latLong;

--- a/src/PackagePrivate/Precision.php
+++ b/src/PackagePrivate/Precision.php
@@ -6,7 +6,7 @@ namespace DataValues\Geo\PackagePrivate;
 
 class Precision {
 
-	private $precision;
+	private float $precision;
 
 	public function __construct( float $precisionInDegrees ) {
 		if ( $precisionInDegrees < -360 || $precisionInDegrees > 360 ) {

--- a/src/PackagePrivate/PrecisionParser.php
+++ b/src/PackagePrivate/PrecisionParser.php
@@ -6,8 +6,8 @@ use ValueParsers\ValueParser;
 
 class PrecisionParser {
 
-	private $latLongParser;
-	private $precisionDetector;
+	private ValueParser $latLongParser;
+	private PrecisionDetector $precisionDetector;
 
 	public function __construct( ValueParser $latLongParser, PrecisionDetector $precisionDetector ) {
 		$this->latLongParser = $latLongParser;

--- a/src/Parsers/DdCoordinateParser.php
+++ b/src/Parsers/DdCoordinateParser.php
@@ -34,7 +34,7 @@ class DdCoordinateParser extends LatLongParserBase {
 	/**
 	 * @param ParserOptions|null $options
 	 */
-	public function __construct( ParserOptions $options = null ) {
+	public function __construct( ?ParserOptions $options = null ) {
 		$options = $options ?: new ParserOptions();
 		$options->defaultOption( self::OPT_DEGREE_SYMBOL, '°' );
 
@@ -107,7 +107,7 @@ class DdCoordinateParser extends LatLongParserBase {
 			}
 		}
 
-		return ( 1 === $match );
+		return ( $match === 1 );
 	}
 
 	/**

--- a/src/Parsers/DmCoordinateParser.php
+++ b/src/Parsers/DmCoordinateParser.php
@@ -29,7 +29,7 @@ class DmCoordinateParser extends DdCoordinateParser {
 	/**
 	 * @param ParserOptions|null $options
 	 */
-	public function __construct( ParserOptions $options = null ) {
+	public function __construct( ?ParserOptions $options = null ) {
 		$options = $options ?: new ParserOptions();
 		$options->defaultOption( self::OPT_MINUTE_SYMBOL, "'" );
 
@@ -151,7 +151,7 @@ class DmCoordinateParser extends DdCoordinateParser {
 			);
 		}
 
-		list( $degrees, $minutes ) = $exploded;
+		[ $degrees, $minutes ] = $exploded;
 
 		$minutes = substr( $minutes, 0, -1 );
 

--- a/src/Parsers/DmsCoordinateParser.php
+++ b/src/Parsers/DmsCoordinateParser.php
@@ -27,9 +27,9 @@ class DmsCoordinateParser extends DmCoordinateParser {
 	public const OPT_SECOND_SYMBOL = 'second';
 
 	/**
-	 * @param ParserOptions|null $options
+	 * @param ?ParserOptions $options
 	 */
-	public function __construct( ParserOptions $options = null ) {
+	public function __construct( ?ParserOptions $options = null ) {
 		$options = $options ?: new ParserOptions();
 		$options->defaultOption( self::OPT_SECOND_SYMBOL, '"' );
 

--- a/src/Parsers/FloatCoordinateParser.php
+++ b/src/Parsers/FloatCoordinateParser.php
@@ -71,7 +71,7 @@ class FloatCoordinateParser extends LatLongParserBase {
 			}
 		}
 
-		return ( 1 === $match );
+		return ( $match === 1 );
 	}
 
 	/**

--- a/src/Parsers/GlobeCoordinateParser.php
+++ b/src/Parsers/GlobeCoordinateParser.php
@@ -33,10 +33,10 @@ class GlobeCoordinateParser implements ValueParser {
 	 */
 	public const OPT_GLOBE = 'globe';
 
-	private $options;
-	private $latLongPrecisionParser;
+	private ParserOptions $options;
+	private ?LatLongPrecisionParser $latLongPrecisionParser = null;
 
-	public function __construct( ParserOptions $options = null ) {
+	public function __construct( ?ParserOptions $options = null ) {
 		$this->options = $options ?: new ParserOptions();
 
 		$this->options->defaultOption( ValueParser::OPT_LANG, 'en' );
@@ -71,6 +71,9 @@ class GlobeCoordinateParser implements ValueParser {
 		);
 	}
 
+	/**
+	 * @return LatLongPrecisionParser
+	 */
 	private function getParser() {
 		if ( $this->latLongPrecisionParser === null ) {
 			$this->latLongPrecisionParser = new LatLongPrecisionParser( $this->options );

--- a/src/Parsers/LatLongParser.php
+++ b/src/Parsers/LatLongParser.php
@@ -66,7 +66,7 @@ class LatLongParser implements ValueParser {
 	 */
 	private $options;
 
-	public function __construct( ParserOptions $options = null ) {
+	public function __construct( ?ParserOptions $options = null ) {
 		$this->options = $options ?: new ParserOptions();
 		$this->options->defaultOption( ValueParser::OPT_LANG, 'en' );
 	}

--- a/src/Parsers/LatLongParserBase.php
+++ b/src/Parsers/LatLongParserBase.php
@@ -38,7 +38,7 @@ abstract class LatLongParserBase implements ValueParser {
 	 */
 	private $options;
 
-	public function __construct( ParserOptions $options = null ) {
+	public function __construct( ?ParserOptions $options = null ) {
 		$this->options = $options ?: new ParserOptions();
 
 		$this->options->defaultOption( ValueParser::OPT_LANG, 'en' );
@@ -94,7 +94,7 @@ abstract class LatLongParserBase implements ValueParser {
 			throw new ParseException( 'Not a valid geographical coordinate', $rawValue, static::FORMAT_NAME );
 		}
 
-		list( $latitude, $longitude ) = $normalizedCoordinateSegments;
+		[ $latitude, $longitude ] = $normalizedCoordinateSegments;
 
 		return new LatLongValue(
 			$this->getParsedCoordinate( $latitude ),
@@ -183,6 +183,10 @@ abstract class LatLongParserBase implements ValueParser {
 		return $coordinateSegment;
 	}
 
+	/**
+	 * @param string $optionName
+	 * @return mixed
+	 */
 	protected function getOption( string $optionName ) {
 		return $this->options->getOption( $optionName );
 	}

--- a/src/Values/GlobeCoordinateValue.php
+++ b/src/Values/GlobeCoordinateValue.php
@@ -19,19 +19,13 @@ use InvalidArgumentException;
  */
 class GlobeCoordinateValue implements DataValue {
 
-	private $latLong;
-
-	/**
-	 * @var float|null
-	 */
-	private $precision;
+	private LatLongValue $latLong;
+	private ?float $precision;
 
 	/**
 	 * IRI of the globe on which the location resides.
-	 *
-	 * @var string
 	 */
-	private $globe;
+	private string $globe;
 
 	/**
 	 * Wikidata concept URI for the Earth. Used as default value when no other globe was specified.
@@ -40,12 +34,12 @@ class GlobeCoordinateValue implements DataValue {
 
 	/**
 	 * @param LatLongValue $latLong
-	 * @param float|int|null $precision in degrees, e.g. 0.01.
-	 * @param string|null $globe IRI, defaults to 'http://www.wikidata.org/entity/Q2'.
+	 * @param ?float $precision in degrees, e.g. 0.01.
+	 * @param ?string $globe IRI, defaults to 'http://www.wikidata.org/entity/Q2'.
 	 *
 	 * @throws IllegalValueException
 	 */
-	public function __construct( LatLongValue $latLong, float $precision = null, string $globe = null ) {
+	public function __construct( LatLongValue $latLong, ?float $precision = null, ?string $globe = null ) {
 		$this->assertIsPrecision( $precision );
 
 		if ( $globe === null ) {
@@ -143,7 +137,7 @@ class GlobeCoordinateValue implements DataValue {
 	 * @throws InvalidArgumentException
 	 */
 	public function unserialize( $value ) {
-		$this->__unserialize( json_decode( $value) );
+		$this->__unserialize( json_decode( $value ) );
 	}
 
 	public function __unserialize( array $data ): void {

--- a/src/Values/LatLongValue.php
+++ b/src/Values/LatLongValue.php
@@ -21,8 +21,8 @@ use InvalidArgumentException;
  */
 class LatLongValue implements DataValue {
 
-	private $latitude;
-	private $longitude;
+	private float $latitude;
+	private float $longitude;
 
 	/**
 	 * @param float|int $latitude Latitude in degrees within the range [-360, 360]
@@ -82,7 +82,7 @@ class LatLongValue implements DataValue {
 	public function getSerializationForHash(): string {
 		$data = $this->serialize();
 		return 'C:' . strlen( static::class ) . ':"' . static::class .
-		       '":' . strlen( $data ) . ':{' . $data . '}';
+			'":' . strlen( $data ) . ':{' . $data . '}';
 	}
 
 	public function getCopy(): self {

--- a/tests/unit/GlobeMathTest.php
+++ b/tests/unit/GlobeMathTest.php
@@ -51,14 +51,14 @@ class GlobeMathTest extends TestCase {
 		// west to east. For other globes see http://planetarynames.wr.usgs.gov/TargetCoordinates
 		return [
 			// Yes, there really are nine ways to describe the same point
-			[ 0, 0,    0,    0 ],
-			[ 0, 0,    0,  360 ],
-			[ 0, 0,    0, -360 ],
-			[ 0, 0,  360,    0 ],
-			[ 0, 0, -360,    0 ],
-			[ 0, 0,  180,  180 ],
-			[ 0, 0,  180, -180 ],
-			[ 0, 0, -180,  180 ],
+			[ 0, 0, 0, 0 ],
+			[ 0, 0, 0, 360 ],
+			[ 0, 0, 0, -360 ],
+			[ 0, 0, 360, 0 ],
+			[ 0, 0, -360, 0 ],
+			[ 0, 0, 180, 180 ],
+			[ 0, 0, 180, -180 ],
+			[ 0, 0, -180, 180 ],
 			[ 0, 0, -180, -180 ],
 
 			// Earth (default) vs. other globes
@@ -68,21 +68,21 @@ class GlobeMathTest extends TestCase {
 			[ 0, 350, 0, 350, 'Vulcan' ],
 
 			// Make sure the methods do not simply return true
-			[ 0, 0,   0,  180, null, false ],
-			[ 0, 0,   0, -180, null, false ],
-			[ 0, 0, 180,    0, null, false ],
-			[ 0, 0, 180,  360, null, false ],
+			[ 0, 0, 0, 180, null, false ],
+			[ 0, 0, 0, -180, null, false ],
+			[ 0, 0, 180, 0, null, false ],
+			[ 0, 0, 180, 360, null, false ],
 
 			// Dark side of the Moon, erm Earth
-			[ 0, -180,    0,  180 ],
-			[ 0, -180,    0, -180 ],
-			[ 0, -180,  180,    0 ],
-			[ 0, -180, -180,    0 ],
+			[ 0, -180, 0, 180 ],
+			[ 0, -180, 0, -180 ],
+			[ 0, -180, 180, 0 ],
+			[ 0, -180, -180, 0 ],
 			[ 0, -180, -360, -180 ],
 
 			// Half way to the north pole
-			[ 45, 0,  45, -360 ],
-			[ 45, 0, 135,  180 ],
+			[ 45, 0, 45, -360 ],
+			[ 45, 0, 135, 180 ],
 			[ 45, 0, 135, -180 ],
 
 			// North pole is a special case, drop longitude
@@ -91,9 +91,9 @@ class GlobeMathTest extends TestCase {
 			[ 90, 0, -270, 180 ],
 			[ 90, 0, -90, 0, null, false ],
 			// Same for south pole
-			[ -90,  0,  -90,  123 ],
-			[ -90,  0,  270,    0 ],
-			[ -90,  0,  270, -180 ],
+			[ -90, 0, -90, 123 ],
+			[ -90, 0, 270, 0 ],
+			[ -90, 0, 270, -180 ],
 
 			// Make sure we cover all cases in the code
 			[ 10, 10, 10, 10 ],

--- a/tests/unit/Values/GlobeCoordinateValueTest.php
+++ b/tests/unit/Values/GlobeCoordinateValueTest.php
@@ -302,7 +302,6 @@ class GlobeCoordinateValueTest extends TestCase {
 		yield [ [ 'latitude' => '1.23a', 'longitude' => '3.45b' ] ];
 	}
 
-
 	/**
 	 * @dataProvider withPrecisionProvider
 	 */


### PR DESCRIPTION
This repository is currently using version 34 of the Mediawiki coding style phpcs rules. If the code aims to comply with Mediawiki style guidelines, it makes sense that it continues to comply at current versions of the rules.

Besides being simply different, the newer versions of the rules introduce, for example,
MediaWiki.Usage.NullableType.ExplicitNullableTypes, which enforces compliance with coming deprecation rules in PHP 8.4 concerning nullable types. If the code does not remove the soon-to-be-deprecated form of nullable type declarations, the library will no longer be usable in Mediawiki for PHP 8.4 deployments.

Resolves #222

Bug: T379481