### PR TITLE
Bump version to 4.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,13 @@ employees for the [Wikidata project](https://wikidata.org/).
 
 ## Release notes
 
+### 4.5.0 (2024-12-10)
+
+* Drop support for PHP 7.2, 7.3
+* Upgrade codesniffer rules to current `mediawiki/mediawiki-codesniffer` version (45.0.0)
+* Make nullable type parameter declarations explicit for compatibility with PHP 8.4
+* Start testing with modern versions of PHP (8.1-8.4)
+
 ### 4.4.0 (2022-10-21)
 
 * Implemented `__serialize` and `__unserialize` in `LatLongValue` and `GlobeCoordinateValue`,

--- a/README.md
+++ b/README.md
@@ -105,10 +105,10 @@ employees for the [Wikidata project](https://wikidata.org/).
 
 ### 4.5.0 (2024-12-10)
 
-* Drop support for PHP 7.2, 7.3
-* Upgrade codesniffer rules to current `mediawiki/mediawiki-codesniffer` version (45.0.0)
-* Make nullable type parameter declarations explicit for compatibility with PHP 8.4
-* Start testing with modern versions of PHP (8.1-8.4)
+* Dropped support for PHP 7.3
+* Improved support for PHP 8.4 by explicitly declaring nullable types
+* Upgraded `mediawiki/mediawiki-codesniffer` rules to version 45.0.0
+* Added testing with PHP 8.2 and 8.3
 
 ### 4.4.0 (2022-10-21)
 


### PR DESCRIPTION
 * Drop support for PHP 7.2, 7.3
 * Upgrade codesniffer rules to current `mediawiki/mediawiki-codesniffer` version (45.0.0)
 * Make nullable type parameter declarations explicit for compatibility with PHP 8.4
 * Start testing with modern versions of PHP (8.1-8.4)