### PR TITLE
Restore PHP 7.4 support

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,6 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         php:
+          - '7.4'
           - '8.0'
           - '8.1'
           - '8.2'

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
 		"docs": "https://github.com/DataValues/Geo/#usage"
 	},
 	"require": {
-		"php": ">=8.0",
+		"php": ">=7.4",
 		"data-values/data-values": "^3.0|^2.0|^1.0|~0.1",
 		"data-values/interfaces": "^1.0.0|^0.2.0",
 		"symfony/polyfill-php80": "^1.18.1"

--- a/src/Formatters/LatLongFormatter.php
+++ b/src/Formatters/LatLongFormatter.php
@@ -368,7 +368,11 @@ class LatLongFormatter implements ValueFormatter {
 		return sprintf( '%.' . ( $digits > 0 ? $digits : 0 ) . 'F', $number );
 	}
 
-	private function defaultOption( string $option, mixed $default ): void {
+	/**
+	 * @param string $option
+	 * @param mixed $default
+	 */
+	private function defaultOption( string $option, $default ): void {
 		if ( !$this->options->hasOption( $option ) ) {
 			$this->options->setOption( $option, $default );
 		}

--- a/src/Parsers/LatLongParserBase.php
+++ b/src/Parsers/LatLongParserBase.php
@@ -48,7 +48,11 @@ abstract class LatLongParserBase implements ValueParser {
 		$this->defaultOption( self::OPT_SEPARATOR_SYMBOL, ',' );
 	}
 
-	private function defaultOption( string $option, mixed $default ): void {
+	/**
+	 * @param string $option
+	 * @param mixed $default
+	 */
+	private function defaultOption( string $option, $default ): void {
 		if ( !$this->options->hasOption( $option ) ) {
 			$this->options->setOption( $option, $default );
 		}


### PR DESCRIPTION
Per #231, re-enable support and CI testing for PHP 7.4. Mediawiki test infrastructure still depends on PHP 7.4 at the current time.

Bug: T379481